### PR TITLE
Rung 2: projector cross-talk

### DIFF
--- a/openspec/changes/rung2-projector-crosstalk/.openspec.yaml
+++ b/openspec/changes/rung2-projector-crosstalk/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-12

--- a/openspec/changes/rung2-projector-crosstalk/design.md
+++ b/openspec/changes/rung2-projector-crosstalk/design.md
@@ -1,0 +1,68 @@
+## Context
+
+Rung 0 proved the linear floor is clean under a single, deliberately benign projector: mean-centered PCA with no per-feature standardization. Rung 1 proved the methylation `rev.logit` is invertible by M-value integration and is not a standing cross-talk source, and — because `logit` acts coordinate-wise — mooted the heterogeneous-baseline rung. The specificity study's magnitude→orientation cross-talk therefore enters above the methylation representation. The obvious next single factor is the **projector**: the production trajectory pipeline does not use Rung 0's PCA — `evaluation.py` standardizes-and-concatenates (`concat`) or builds an SNF spectral embedding (`snf`), and the package also ships a supervised PLS-DA projector (`stats/pls.py`). Each of these transforms the clean injected geometry before `estimate_difference` measures it, and a standardizing, label-conditioned, or graph-spectral map can rotate or rescale a similarity transform that PCA leaves intact.
+
+Rung 2 holds everything from Rung 0/1 fixed (geometry injection, two stages, M-value space so there is no `rev.logit` distortion, the production estimators, the seed-averaging and null-floor reporting) and varies **only the projector**. It reuses the Rung-0/1 helpers and the production `stats/pls.fit_plsda_transform` and `stats/snf` functions unchanged, so the projectors under test are the package's own, not reimplementations.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A deterministic, seed-reproducible test bed that injects the known Rung-0 2-stage geometry in a clean M-value feature space and measures `delta`/`angle` through a **selectable projector**.
+- Compare four projectors on identical data: **PCA** (reference floor), **standardize** (the `concat` transform), **PLS-DA** (supervised), **SNF** spectral (graph-spectral).
+- Report, per projector, absolute distortion vs the intended geometry and cross-talk (magnitude→`angle`, orientation→`delta`) against the PCA floor and a per-projector `none` null; sweep effect size and latent dimensionality to find any onset.
+- A dedicated **supervised-leakage probe**: detect whether PLS-DA aligns a `none` (null) trajectory with the group axis.
+- A reproducible findings writeup with the per-projector table and the Rung-3 gate decision.
+
+**Non-Goals:**
+- No true multi-omic concatenation of heterogeneous-scale blocks (single block here; heterogeneous concat is a candidate Rung 3).
+- No cross-omic cascade, full InterSIM generator, or `rev.logit` distortion (methylation is fixed in M-space — the clean linear frame).
+- No `evaluation.py` end-to-end harness, no RRPP rejection-rate sweep, no shape statistic, no purity metric.
+- Not a power study — this is a mechanistic projector-distortion characterization.
+
+## Decisions
+
+**1. Reuse the Rung-0/1 geometry injection in M-value space; vary only the projector.**
+Per-(group, stage) means are built exactly as in Rung 0 (`a_feat`, `step_B` for `none`/`magnitude`/`orientation`), drawn with isotropic MVN noise. Because Rung 1 established M-value integration as the correct representation, the feature space *is* M-space — there is no `rev.logit` step, so the only thing distinguishing Rung 2 from the Rung-0 clean floor is the projector. Alternative considered: layer the projector swap on top of β/`rev.logit` — rejected, because that would conflate the (already-characterized) nonlinearity with the projector and break the one-factor discipline.
+
+**2. A single `projector` knob with four options; a uniform measurement contract.**
+Each projector maps the `(n_samples × n_features)` feature matrix to a `(n_samples × n_components)` latent matrix `Y`, after which the *identical* Rung-0 measurement runs: 2-group × 2-stage design via `get_model_matrix`/`build_ls_means`, two-group contrast, `estimate_difference` → `delta`/`angle` (shape `nan`, dropped). The projectors:
+- `pca`: `PCA(n_components)` on mean-centered features (Rung-0 reference).
+- `standardize`: per-feature z-score (matching `evaluation.py:_concat_integration`, `std==0 → 1`), then `PCA(n_components)` — isolating standardization from the PCA rotation by composing them so the difference from `pca` is *only* the scaling.
+- `plsda`: `fit_plsda_transform(X, y, n_components)` with the supervised label `y` (see Decision 3).
+- `snf`: `get_affinity_matrix` per (single) block → `SNF` → `get_spectral(n_components)`.
+Alternative considered: route through `evaluation.integrate_semisynthetic_dataset` — rejected because that harness expects a multi-omic `SemiSyntheticTrajectoryDataset` and bundles RRPP; calling the projector functions directly keeps the rung single-factor and fast.
+
+**3. PLS-DA label is the group; the `none` null is the leakage control.**
+PLS-DA is supervised and needs a class label. The trajectory question is about *group* differences, so the label is the group membership (A/B), matching how a practitioner would use PLS-DA to separate groups before inspecting trajectories. This is exactly the configuration that can manufacture group-aligned latent structure, so the `none` manipulation (identical group trajectories) is the critical control: under an honest projector `none` stays at the null floor; under label leakage PLS-DA invents a group separation. Alternative labels considered: stage, or group×stage — noted as a secondary probe, but group is the headline because it is the production classification target and the worst-case leakage source.
+
+**4. Cross-talk is read against two references: the PCA floor and the per-projector `none` null.**
+Absolute distortion compares measured `delta`/`angle` to the intended targets (`signal_scale·(c−1)`, `θ`). Cross-talk (magnitude→`angle`, orientation→`delta`) is read against the *same projector's* `none` floor at the same settings, so a projector that is merely noisy is separated from one that systematically rotates/rescales. The PCA floor is the cross-projector baseline: a clean projector matches PCA within tolerance. Reporting is mean ± spread over the Rung-0 seed set.
+
+**5. Latent dimensionality is swept per projector.**
+PCA/standardize/PLS-DA take `n_components`; SNF takes `spectral_components`. The injected geometry lives in a low-dimensional subspace, but a projector may need enough components to retain it (or, for SNF, may distort it regardless of `k`). A small sweep over component count locates whether cross-talk is a dimensionality artifact (too few retained directions) or intrinsic to the projector. Effect size (`signal_scale`/`c`/`θ`) is swept jointly to find any onset, as in Rung 1.
+
+**6. SNF angles are interpreted with care.**
+SNF spectral coordinates are eigenvectors of a fused sample-similarity graph: they have no fixed sign, scale, or feature-space alignment, so a measured `angle`/`delta` in SNF latent space is not directly comparable in *units* to PCA. The test bed therefore reports SNF results primarily as *recovery vs null* (does the injected geometry separate from `none`?) and flags that absolute magnitude is embedding-relative, rather than asserting a unit-matched distortion. This is itself a finding: a projector whose latent metric is not commensurable with the injected geometry is a cross-talk risk for the production `snf` path.
+
+**7. Measurement, seeds, and reporting are identical to Rung 0/1.**
+No per-feature standardization is applied *except* inside the `standardize` projector (that is the point of that arm); the `pca` arm stays mean-centered-only so it reproduces the Rung-0 floor exactly. Same seed set, same "near zero relative to the `none` floor and a stated tolerance" language.
+
+## Risks / Trade-offs
+
+- [A clean result is near-tautological if the geometry is forced into every projector's retained subspace] → Sweep component count and effect size and report recovery as a function of them, so "clean" is conditional and informative, not constructed.
+- [PLS-DA leakage could be masked if `n_components` is large relative to samples (overfitting separates everything)] → Probe `none` explicitly across a component sweep and small sample sizes; report the `none`-floor inflation directly rather than only the signal arms.
+- [SNF latent metric is not unit-commensurable with feature-space geometry] → Report SNF as recovery-vs-null and label absolute magnitudes embedding-relative (Decision 6); do not over-claim a numeric distortion factor.
+- [Standardize arm is degenerate on isotropic noise] → With isotropic MVN noise all features share scale, so z-scoring is near-identity and the `standardize` arm may match `pca` trivially. Mitigation: optionally inject heteroscedastic per-feature noise (a single anisotropy knob) so standardization actually does something, while keeping the geometry known; flagged as an open question on whether to include heteroscedasticity in the headline run.
+- [Cross-talk confounded by MC noise] → Average over the Rung-0 seed set and read cross-talk against the per-projector `none` floor at the same settings.
+
+## Migration Plan
+
+Not applicable — this is additive: one new module under `src/motco/simulations/`, its tests, and a driver script. No existing module, spec, or public API changes. The change is archived once findings land, following the Rung-0/1 pattern.
+
+## Open Questions
+
+- Whether to include a **heteroscedastic-noise** knob so the `standardize` arm is non-trivial in the headline run, or keep isotropic noise and treat standardization-on-isotropic as a (informative) near-identity baseline with anisotropy as a secondary sweep.
+- The PLS-DA **component count** for the headline table, and whether to add a small-sample leakage stress point where overfitting is most likely.
+- Whether SNF's `K`/`k`/`t` defaults from `evaluation.py:_snf_integration` are reused verbatim or pinned to test-bed-appropriate values given the small synthetic sample sizes.
+- Whether the findings writeup stays in the change folder (matching Rung 0/1) or graduates to `src/motco/simulations/` for longer-term visibility.
+- Whether the Rung-3 gate points at heterogeneous multi-omic **concatenation** or the **cross-omic coupling**, decided by which projector(s) leak here.

--- a/openspec/changes/rung2-projector-crosstalk/findings.md
+++ b/openspec/changes/rung2-projector-crosstalk/findings.md
@@ -1,0 +1,132 @@
+## Rung 2 — Projector Cross-talk: Findings
+
+### What this experiment does
+
+Rung 0 proved the linear floor is clean under one deliberately benign projector (mean-centered PCA). Rung 1 showed the methylation `rev.logit` is inverted coordinate-wise by M-value integration, so it is not a standing cross-talk source — the leak must enter **downstream of the methylation representation**, in the integration/projection step. Rung 2 adds **exactly one** new factor: the **projector**.
+
+We reuse the Rung-0 geometry injection **unchanged** — the known 2-stage geometry (`none`/`magnitude`/`orientation`) in a clean linear feature space (the methylation **M-value frame**, so there is no `rev.logit` distortion) — and measure `delta`/`angle` through four projectors, holding the estimator path (`get_model_matrix`/`build_ls_means`/`estimate_difference`, two-group contrast) identical to Rung 0/1:
+
+- **`pca`** — mean-centered PCA (the Rung-0/1 reference floor).
+- **`standardize`** — per-feature z-score (the transform inside the production `concat` integration, `evaluation.py:_concat_integration`), then PCA.
+- **`plsda`** — supervised PLS-DA latent space, conditioned on the group label (`stats/pls.fit_plsda_transform`).
+- **`snf`** — graph-spectral embedding (`stats/snf`). SNF *fusion* requires ≥ 2 networks, so on this single-block test bed the arm reduces to `get_affinity_matrix → get_spectral` — the per-block core of the production `snf` path.
+
+Cross-talk is read against each projector's own `none` null and against the PCA floor. A second pass under **heteroscedastic (anisotropic) per-feature noise** stresses the projectors where they differ most.
+
+---
+
+### Reproduction parameters
+
+| Parameter               | Value  |
+|-------------------------|--------|
+| `n_features`            | 50     |
+| `n_samples_per_cell`    | 40 (→ 160 samples) |
+| `signal_scale` (‖a‖)    | 5.0    |
+| `noise_scale` (σ)       | 1.0    |
+| `scale_c` (magnitude)   | 2.0    |
+| `angle_theta` (orient.) | 45°    |
+| `n_components`          | 2 (headline); sweep 2/3/5/10 |
+| `anisotropy`            | 0 (headline); 1.5 (stress) |
+| `snf_K` / `snf_eps`     | 20 / 0.5 |
+| Seeds averaged over     | 0–9    |
+
+```bash
+.venv/bin/python scripts/projector_recovery_probe.py
+```
+
+Intended geometry: magnitude target `delta = signal_scale·(c−1) = 5.0`; orientation target `angle = 45°`.
+
+---
+
+### Axis 1 — Per-projector recovery on the clean isotropic floor
+
+mean ± SD over seeds 0–9, `n_components = 2`:
+
+| projector   | manip       | δ mean | δ SD | θ mean | θ SD |
+|-------------|-------------|-------:|-----:|-------:|-----:|
+| **pca**     | none        | 0.17 | 0.13 | 6.6° | 5.2 |
+| **pca**     | magnitude   | **5.17** | 0.16 | 5.4° | 4.2 |
+| **pca**     | orientation | 0.26 | 0.21 | **47.8°** | 3.9 |
+| standardize | none        | 0.15 | 0.12 | 6.4° | 4.8 |
+| standardize | magnitude   | 3.91 | 0.17 | 5.1° | 3.5 |
+| standardize | orientation | 0.25 | 0.18 | **49.6°** | 4.4 |
+| plsda       | none        | 0.17 | 0.12 | **19.9°** | **40.6** |
+| plsda       | magnitude   | 3.39 | 0.28 | 3.9° | 2.4 |
+| plsda       | orientation | 0.89 | 0.46 | **110.1°** | 34.6 |
+| snf         | none        | 0.02 | 0.01 | 14.1° | 8.2 |
+| snf         | magnitude   | 0.17 | 0.02 | **70.1°** | 1.5 |
+| snf         | orientation | 0.04 | 0.02 | 66.0° | 2.6 |
+
+Reading it:
+
+- **PCA is clean** — it reproduces the Rung-0 floor exactly: magnitude δ = 5.17 ≈ the target 5.0 with θ at the null floor, orientation θ = 47.8° ≈ 45° with δ at the null floor. **No cross-talk.**
+- **`standardize` preserves direction but rescales magnitude.** Orientation recovers cleanly (49.6°) and angles stay at the null floor for every manipulation, so **standardization introduces no magnitude→orientation cross-talk**. Its only effect is a *uniform* magnitude rescale (δ 5.17 → 3.91): z-scoring divides each feature by its total (signal+noise) std, shrinking the signal-carrying features. This is a units change, not a rotation.
+- **PLS-DA manufactures cross-talk and an unstable null.** Orientation comes out **110°** (vs 45° truth) — a gross rotation — and the `none` null angle is **19.9° ± 40.6°**: inflated and wildly unstable. With two classes, the one-hot label defines only **one** reliable discriminant axis, so the second retained PLS axis is essentially arbitrary and scrambles the trajectory direction. The δ floor is *not* inflated (0.17), so the leakage is specifically in **angle**.
+- **SNF produces magnitude→angle cross-talk.** A pure `magnitude` manipulation registers **70°** of angle. SNF magnitudes are tiny and embedding-relative (δ ≈ 0.02–0.17, not comparable in units to the feature-space target), so we report SNF as recovery-vs-null: it *does* separate signal from `none`, but the spectral embedding's metric is not commensurable with the injected geometry, and it rotates magnitude into angle.
+
+### Axis 2 — Heteroscedastic noise: where the projectors diverge
+
+Same run with `anisotropy = 1.5` (per-feature noise std `× exp(1.5·z)`):
+
+| projector   | manip       | δ mean | θ mean | θ SD |
+|-------------|-------------|-------:|-------:|-----:|
+| **pca**     | none        | 4.92 | **139.6°** | 32.8 |
+| **pca**     | magnitude   | 5.90 | **129.5°** | 44.2 |
+| **pca**     | orientation | 4.50 | **144.7°** | 24.2 |
+| **standardize** | none    | 0.12 | **4.1°** | 2.3 |
+| **standardize** | magnitude | 4.55 | **4.5°** | 2.3 |
+| **standardize** | orientation | 0.59 | **45.8°** | 5.2 |
+| plsda       | none        | 0.10 | 3.7° | 3.7 |
+| plsda       | magnitude   | 4.15 | 2.6° | 1.5 |
+| plsda       | orientation | 0.48 | 57.2° | 14.2 |
+| snf         | none        | 0.39 | 93.1° | 64.5 |
+| snf         | magnitude   | 0.43 | 88.4° | 66.1 |
+| snf         | orientation | 0.39 | 102.2° | 59.1 |
+
+This is the decisive contrast:
+
+- **Raw PCA collapses.** Under heteroscedastic noise the high-variance noise features dominate the top components, so the signal falls out of the retained subspace and *everything* — including `none` — registers ~130–145° of spurious angle and large spurious δ. Mean-centered PCA has no defense against features on different scales.
+- **`standardize` rescues it completely.** Per-feature z-scoring equalizes the noise scales, putting the signal back in the top components: orientation recovers (45.8°), magnitude stays direction-clean (4.5°), and the `none` floor returns to ~4°. **This is exactly why the production `concat` path standardizes** — and it is clean.
+- **PLS-DA** is also robust to anisotropy (it ignores feature scale by construction) but still mildly distorts orientation (57°).
+- **SNF** stays scrambled (~90–100°, huge variance): its Euclidean affinity is dominated by the high-variance features just as raw PCA is.
+
+### Axis 3 — Dimensionality and effect-size sweeps
+
+- **Dimensionality (k = 2/3/5/10):** the `none` angle floor rises with retained components for *every* projector (the Rung-0 k-noise effect: each extra noise PC adds angular spread) — pca `none` θ: 6.6 → 9.4 → 11.3 → 15.9. This is a generic measurement property, not projector-specific. The projector-specific distortions are **intrinsic, not dimensionality artifacts**: PLS-DA orientation stays wrong (110° at k=2, ~70° at k≥3) and SNF magnitude→angle stays ~70° at every k. PLS-DA's *unstable null* is worst at k = 2 (19.9° ± 40.6°) and stabilizes by k = 5 (12.2° ± 4.3°) — consistent with the "only one reliable discriminant axis for two classes" mechanism.
+- **Effect size (`signal_scale` = 2/5/8/12):** PCA magnitude δ tracks the target linearly with no onset (2.17 / 5.17 / 8.16 / 12.15 ≈ scale·(c−1)) and angles stay at the floor. `standardize` magnitude δ **compresses progressively** (2.02 / 3.91 / 4.99 / 5.83) — as the signal grows it contributes more to per-feature variance, so z-scoring divides out more — but angles remain clean throughout (no cross-talk onset). PLS-DA orientation *worsens* with effect size (93° → 123°); SNF magnitude→angle persists (~70–76°) while its δ collapses toward 0 at large signal (graph saturates).
+
+### Axis 4 — Supervised-leakage probe (PLS-DA vs PCA on the `none` null)
+
+| k  | pca θ (null) | plsda θ (null) |
+|---:|-------------:|---------------:|
+| 2  | 6.6° ± 5.2   | **19.9° ± 40.6** |
+| 3  | 9.4° ± 4.8   | 18.6° ± 29.7 |
+| 5  | 11.3° ± 3.9  | 12.2° ± 4.3 |
+| 10 | 15.9° ± 4.4  | 16.9° ± 3.6 |
+
+PLS-DA inflates and destabilizes the **null angle** at low component counts — a group-conditioned projection inventing direction where there is none — and converges to the PCA floor only once enough components are retained. The null **δ** is never inflated. So the supervised projector's leakage is a specifically *orientation* hazard, worst exactly where a practitioner would use it (few components, two classes).
+
+---
+
+### Gate decision
+
+**Which projectors are clean for trajectory geometry?**
+
+| projector   | orientation faithful? | magnitude→angle cross-talk? | robust to feature-scale heterogeneity? | verdict |
+|-------------|:---------------------:|:---------------------------:|:--------------------------------------:|---------|
+| **pca** (raw) | yes (isotropic only) | no (isotropic only) | **no** — collapses under anisotropy | conditional |
+| **standardize** (`concat`) | **yes** | **no** | **yes** | **clean** |
+| **plsda** | **no** (110°+) | in null, at low k | yes | **leaks** |
+| **snf** | no | **yes (~70°)** | no | **leaks** |
+
+1. **The production `concat` projector (per-feature standardize) is clean.** It preserves orientation, introduces no magnitude→orientation cross-talk, and — crucially — is *robust to feature-scale heterogeneity* where raw PCA fails. Its only distortion is a uniform magnitude rescale/compression (δ no longer in source units, compressing with effect size), which does not rotate the geometry and so does not threaten the angle-specificity the trajectory test depends on. The specificity-study cross-talk does **not** originate in single-block standardization.
+
+2. **The production `snf` projector leaks.** Single-block spectral embedding turns a pure magnitude change into ~70° of spurious angle and yields embedding-relative magnitudes that collapse under large effects or heteroscedastic noise. Its latent metric is not commensurable with the injected geometry. **Recommendation:** prefer `concat` over `snf` for trajectory-geometry analysis, or treat `snf` geometry as embedding-relative (recovery-vs-null only), never as a unit-faithful magnitude/angle.
+
+3. **Supervised PLS-DA is unsafe for trajectory geometry.** A two-class label defines only one reliable axis, so retained higher axes scramble orientation (110°+) and inflate the null. PLS-DA is a classifier projector, not a geometry-preserving one — keep it out of the trajectory pipeline.
+
+**Consequence for the ladder.** On a **single** clean block, the production `concat` path is faithful — so the magnitude→orientation cross-talk the specificity study saw is **not** explained by single-block standardization. The remaining untested factors on the clean path are (a) **heterogeneous multi-omic concatenation** — the real pipeline z-scores and concatenates three omic blocks of *different dimensionality and correlation structure*, and unequal block sizes can tilt the pooled PCA toward the larger/most-correlated block, rotating the combined geometry; and (b) the **cross-omic coupling** in the generator, which correlates the blocks. Single-block standardization being clean makes **heterogeneous multi-omic concatenation the next single factor**.
+
+**Decision: Rung 3 = heterogeneous multi-omic concatenation** (methylation in M-space + a second/third block of different dimension and scale, standardized and concatenated as in `concat`), measuring whether unequal block geometry rotates magnitude into orientation. SNF is recorded here as a known-leaky projector and PLS-DA as out-of-scope for geometry; both are settled at this rung.
+
+**Exact reproduction:** seeds 0–9; `n_features = 50`, `n_samples_per_cell = 40`, `signal_scale = 5.0`, `noise_scale = 1.0`, `scale_c = 2.0`, `angle_theta = 45°`, `n_components = 2` (sweep 2/3/5/10), `anisotropy ∈ {0, 1.5}`, `snf_K = 20`, `snf_eps = 0.5`; driver `scripts/projector_recovery_probe.py`.

--- a/openspec/changes/rung2-projector-crosstalk/proposal.md
+++ b/openspec/changes/rung2-projector-crosstalk/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Rung 0 (`rung0-gaussian-existence-proof/findings.md`) proved that under a pure-linear **PCA** projector the production estimators isolate magnitude (`delta`) and orientation (`angle`) with no cross-talk. Rung 1 (`rung1-methylation-nonlinearity/findings.md`) showed the methylation `rev.logit` nonlinearity is fully invertible by M-value integration and is therefore **not** a standing cross-talk source for a correctly-built pipeline — and, because `logit` acts coordinate-wise, it mooted the originally-planned heterogeneous-baseline rung. The specificity study's cross-talk (magnitude leaking into orientation) must therefore enter **downstream of the methylation representation**, in the integration/projection step itself. Rung 0 used a single, deliberately benign projector (mean-centered PCA, no standardization); the production trajectory pipeline does **not** use that projector — it standardizes-and-concatenates (`concat`) or builds an SNF spectral embedding. Rung 2 isolates **exactly one factor: the projector**, and asks whether swapping PCA for a standardizing, supervised, or graph-spectral projector manufactures cross-talk on an otherwise clean linear problem.
+
+## What Changes
+
+- Add a Rung-2 **projector test bed** that reuses the Rung-0/Rung-1 geometry injection unchanged (known 2-stage `none`/`magnitude`/`orientation` geometry in a clean feature space, methylation fixed in **M-value space** per Rung 1's gate decision — no `rev.logit` distortion), then measures `delta`/`angle` through a **selectable projector** instead of the single inline PCA. The estimator path (`get_model_matrix`/`build_ls_means`/`estimate_difference`, two-group contrast) is identical to Rung 0/1.
+- **Projector is the swept independent variable.** Compare, on the same injected geometry:
+  - **PCA** (mean-centered, inline) — the Rung-0/1 reference floor.
+  - **Standardize** (per-feature z-score, then identity/PCA) — the transform inside the production `concat` integration (`evaluation.py:_concat_integration`); isolates the per-feature standardization that Rung 0/1 deliberately deferred.
+  - **PLS-DA** latent space — the supervised production projector (`stats/pls.fit_plsda_transform`); a projector that *uses the group label*, the prime suspect for manufacturing group-aligned structure.
+  - **SNF** spectral embedding — the graph-spectral production projector (`stats/snf`: `get_affinity_matrix` → `SNF` → `get_spectral`); a nonlinear, sample-similarity projector whose latent axes need not align with feature-space geometry.
+- **Stage = 2 only**, so Procrustes `shape` is degenerate and excluded — scope stays magnitude and orientation, identical to Rung 0/1.
+- **Cross-talk characterization per projector:** quantify, against the PCA floor and the per-projector `none` null, (a) absolute distortion of measured `delta`/`angle` vs the intended geometry (magnitude target `signal_scale·(c−1)`, orientation target `θ`) and (b) cross-talk (magnitude→`angle`, orientation→`delta`). Sweep over **effect size** and the projector's **latent dimensionality** (PCA/PLS components, SNF spectral components) to locate any onset.
+- **Supervised-leakage probe (PLS-DA specific):** because PLS-DA conditions the projection on the group label, it can in principle align a *null* (`none`) trajectory with the group axis. The test bed reports the `none`-manipulation `delta`/`angle` under PLS-DA against the PCA floor to detect label-induced spurious geometry.
+- Add a committed **findings writeup** with the per-projector distortion/cross-talk table and the **gate decision for Rung 3**: which projector(s), if any, are clean; whether the production `concat`/`snf` path leaks; and where the next rung should go (heterogeneous multi-omic concatenation, or the cross-omic coupling).
+- **Out of scope (deferred to later proposals):** true **multi-omic** concatenation of heterogeneous-scale blocks (this rung is single-block, methylation-in-M-space, so "concatenation" reduces to standardization; heterogeneous concat is a candidate Rung 3), the cross-omic cascade and full InterSIM generator path, real per-CpG baselines, the `evaluation.py` end-to-end harness with RRPP rejection rates, and any purity metric or power study.
+
+## Capabilities
+
+### New Capabilities
+- `projector-geometry-recovery`: A Rung-2 test bed that injects the known two-stage trajectory geometry into a clean linear (M-value) feature space and measures how trajectory `delta`/`angle` recovery and magnitude↔orientation cross-talk depend on the **projector** — comparing mean-centered PCA against per-feature standardization, supervised PLS-DA, and SNF spectral embedding — at two stages, against the PCA floor and a per-projector null.
+
+### Modified Capabilities
+<!-- None: this is a self-contained new test bed; it does not change requirements of the evaluation harness, generator, or trajectory estimators. -->
+
+## Impact
+
+- **New code:** a Rung-2 test-bed module under `src/motco/simulations/` (e.g. `projector_recovery.py`) plus unit tests under `tests/`, and a driver script under `scripts/`.
+- **New docs:** a findings writeup in the change folder (matching the Rung-0/1 pattern).
+- **Reused, unchanged:** the Rung-0/1 geometry-injection helpers (`simulations/linear_recovery.py`, `simulations/methylation_recovery.py`), the `stats/trajectory.py` estimators, `stats/pls.fit_plsda_transform`, and `stats/snf` (`get_affinity_matrix`/`SNF`/`get_spectral`).
+- **Dependencies:** `numpy`, `scikit-learn`, `pandas` — all already present.
+- **No changes** to `evaluation.py`, `semisynthetic.py`, `generator.py`, `pls.py`, `snf.py`, or any existing spec.

--- a/openspec/changes/rung2-projector-crosstalk/specs/projector-geometry-recovery/spec.md
+++ b/openspec/changes/rung2-projector-crosstalk/specs/projector-geometry-recovery/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: Clean two-stage geometry injection with a selectable projector
+
+The system SHALL provide a generator-free test bed that injects a *known* two-stage trajectory geometry directly in a clean linear (methylation M-value) feature space for two groups under multivariate-normal noise, and measures the trajectory `delta`/`angle` through a **selectable projector**. The test bed MUST reuse the Rung-0 step construction for the per-group steps (manipulations `none`, `magnitude`, `orientation`), MUST NOT apply the methylation `rev.logit` nonlinearity (the feature space is the M-value frame), and MUST hold the measurement path — `get_model_matrix`/`build_ls_means`, the two-group contrast, and `estimate_difference` — identical to Rung 0/1.
+
+#### Scenario: Deterministic dataset from a seed
+
+- **WHEN** the test bed is called with a fixed seed, feature dimension, sample sizes, noise/signal scales, a manipulation, and a projector selection
+- **THEN** it returns measured `delta`/`angle` for the two-group contrast, and repeated calls with the same seed and projector return identical values
+
+#### Scenario: Exactly two stages
+
+- **WHEN** a dataset is generated
+- **THEN** there are exactly two stages per group, so each group's trajectory is a single step vector and Procrustes shape is degenerate and excluded from all reported statistics
+
+### Requirement: Four-projector comparison on identical geometry
+
+The system SHALL expose the projector as an explicit parameter with at least four options: mean-centered **PCA** (the reference floor), per-feature **standardize** (matching the production `concat` integration transform), supervised **PLS-DA** (the production `stats/pls` projector, conditioned on the group label), and **SNF** spectral embedding (the production `stats/snf` graph-spectral projector). Each projector MUST map the same injected feature matrix to a latent matrix that is then measured by the identical estimator path, and the system MUST reuse the package's own `fit_plsda_transform`, `get_affinity_matrix`/`SNF`/`get_spectral` functions rather than reimplementing them.
+
+#### Scenario: PCA arm reproduces the Rung-0 floor
+
+- **WHEN** the projector is PCA on a small-effect `magnitude` and `orientation` manipulation
+- **THEN** `magnitude` moves `delta` and `orientation` moves `angle`, with cross-talk near the `none` baseline — i.e. the Rung-0 clean-floor behavior is reproduced within tolerance
+
+#### Scenario: Each projector measured on the same data
+
+- **WHEN** the same seed and manipulation are run through PCA, standardize, PLS-DA, and SNF
+- **THEN** the system reports each projector's measured `delta`/`angle` so they can be compared against the PCA floor on identical injected geometry
+
+### Requirement: Per-projector distortion and cross-talk characterization
+
+The system SHALL quantify, per projector and as a function of effect size and latent dimensionality, both the absolute distortion of the measured geometry against the intended geometry (magnitude target `signal_scale·(c−1)`, orientation target `θ`) and the cross-talk between facets (a `magnitude` manipulation's effect on `angle`, an `orientation` manipulation's effect on `delta`). Cross-talk MUST be read against the *same projector's* `none` null at the same settings, and the PCA floor MUST serve as the cross-projector reference.
+
+#### Scenario: Cross-talk reported against the per-projector null and the PCA floor
+
+- **WHEN** all manipulations have been run for a given projector over the seed set
+- **THEN** the result reports, for that projector, the `magnitude`→`angle` and `orientation`→`delta` cross-talk relative to its own `none` floor, and the deviation of its `delta`/`angle` from the PCA floor, so projector-induced leakage is separated from finite-sample noise
+
+#### Scenario: Dimensionality and effect-size sweep
+
+- **WHEN** the test bed is run across a range of latent component counts and effect sizes
+- **THEN** the result reports measured `delta`/`angle` and cross-talk as a function of both, so any onset of projector-induced distortion can be located
+
+### Requirement: Supervised-leakage probe
+
+The system SHALL provide a probe that detects whether the supervised PLS-DA projector, conditioned on the group label, manufactures spurious group-aligned geometry on a null trajectory. The probe MUST report the `none`-manipulation measured `delta`/`angle` under PLS-DA against the PCA floor, including a configuration that stresses leakage (e.g. larger component count relative to sample size).
+
+#### Scenario: Null trajectory under a supervised projector
+
+- **WHEN** the `none` manipulation (identical group trajectories) is measured under PLS-DA
+- **THEN** the probe reports whether the measured `delta`/`angle` remains at the PCA `none` floor or is inflated by the group-conditioned projection, flagging label-induced spurious separation when present
+
+### Requirement: SNF latent metric is reported as embedding-relative
+
+The system SHALL report SNF spectral results primarily as recovery-versus-null (whether the injected geometry separates from the `none` manipulation), and MUST flag that absolute `delta`/`angle` magnitudes in the SNF embedding are embedding-relative — not unit-commensurable with the feature-space targets — rather than asserting a unit-matched distortion factor.
+
+#### Scenario: SNF recovery without over-claimed magnitude
+
+- **WHEN** a `magnitude` or `orientation` manipulation is measured under SNF
+- **THEN** the result reports whether it separates from the `none` null and labels the absolute magnitude as embedding-relative, without claiming a numeric distortion ratio against the feature-space target
+
+### Requirement: Findings writeup
+
+The system SHALL produce a committed findings writeup that records, per projector, the distortion and cross-talk results (with the per-projector `none` floor and the PCA cross-projector reference), the effect-size and dimensionality sweeps, and the supervised-leakage probe, with enough parameter detail to reproduce the run, and SHALL state the gate decision for Rung 3 — which projector(s) are clean, whether the production `concat`/`snf` path leaks, and the next single factor (heterogeneous multi-omic concatenation or cross-omic coupling).
+
+#### Scenario: Findings document exists and is reproducible
+
+- **WHEN** the test bed and sweeps have been run
+- **THEN** a findings document records the per-projector distortion/cross-talk table, the sweeps, the leakage probe, the Rung-3 gate decision, and the exact parameters (seed set, dimensions, noise/signal scale, projector settings, component grid) needed to reproduce them

--- a/openspec/changes/rung2-projector-crosstalk/tasks.md
+++ b/openspec/changes/rung2-projector-crosstalk/tasks.md
@@ -1,0 +1,32 @@
+## 1. Test-bed module scaffold
+
+- [x] 1.1 Create `src/motco/simulations/projector_recovery.py` with a frozen params dataclass reusing the Rung-0/Rung-1 fields (seed, n_features, per-cell sample size, noise/signal scale, manipulation `none`/`magnitude`/`orientation`, scale `c`, angle `θ`, latent `n_components`) plus a `projector` selector (`pca`/`standardize`/`plsda`/`snf`) and an optional anisotropy knob for per-feature noise heteroscedasticity.
+- [x] 1.2 Implement generation by reusing the Rung-0 step construction (`a_feat`, `step_B` per manipulation) for the M-space means `μ_{g,s}` and drawing `x = μ + N(0, Σ)` from a seeded `np.random.default_rng`; reuse the Rung-0/Rung-1 helpers rather than copying them. No `rev.logit` (the feature space is the M-value frame).
+- [x] 1.3 Validate params (≥2 samples per cell, `n_components` in range for the chosen projector, positive noise/signal scales, known projector selector) and raise a clear module-specific error on bad input.
+
+## 2. Projector abstraction and measurement
+
+- [x] 2.1 Implement the four projectors behind a uniform `(X, y) → Y` contract: `pca` (mean-centered `PCA`), `standardize` (per-feature z-score matching `evaluation.py:_concat_integration`, then `PCA`), `plsda` (`stats/pls.fit_plsda_transform` with the group label), `snf` (`stats/snf`: `get_affinity_matrix` → `SNF` → `get_spectral`). Reuse the package functions; do not reimplement.
+- [x] 2.2 After projection, build the 2-group × 2-stage design via `get_model_matrix`/`build_ls_means` and the two-group contrast (identical to Rung 0/1) and call `estimate_difference` on the projected `Y`; extract `delta` and `angle` (shape is `nan` at 2 stages and dropped).
+- [x] 2.3 Confirm the `pca` arm reproduces the Rung-0 floor exactly (mean-centered only, no standardization on that arm).
+
+## 3. Comparison, sweeps, and probes
+
+- [x] 3.1 Add a per-projector driver that runs all manipulations over the Rung-0 seed set and returns mean ± spread of `delta`/`angle` per (projector, manipulation), with `none` as the per-projector null floor and the PCA arm as the cross-projector reference.
+- [x] 3.2 Add the effect-size × latent-dimensionality sweep (component count per projector; `signal_scale`/`c`/`θ`) and compute distortion metrics: absolute (measured vs intended `signal_scale·(c−1)` / `θ`) and cross-talk (magnitude→`angle`, orientation→`delta`) read against the per-projector `none` floor.
+- [x] 3.3 Add the supervised-leakage probe: measure the `none` manipulation under `plsda` against the PCA `none` floor, including a small-sample / larger-component stress configuration; report any inflation.
+- [x] 3.4 Report SNF results as recovery-vs-null and label absolute magnitudes embedding-relative (do not assert a unit-matched distortion ratio).
+
+## 4. Tests
+
+- [x] 4.1 Unit test: deterministic output for a fixed seed and projector; exactly two stages; reused Rung-0 geometry construction.
+- [x] 4.2 Unit test (PCA ≈ Rung-0 floor): under `pca` with a small step, `magnitude` moves `delta` and `orientation` moves `angle` with cross-talk near the `none` baseline.
+- [x] 4.3 Unit test (projector contract): each of the four projectors returns a finite `(n_samples × n_components)` latent matrix and a finite `delta`/`angle` on a small synthetic case.
+- [x] 4.4 Unit test (supervised-leakage probe): the probe returns the `none` `delta`/`angle` under `plsda` and the PCA floor so leakage (if any) is quantifiable; assert the probe runs and reports both references.
+- [x] 4.5 Ensure tests are fast (`not slow`) and pass the repo gate: `ruff`, `mypy`, `pytest -m "not slow"`.
+
+## 5. Driver and findings writeup
+
+- [x] 5.1 Add `scripts/projector_recovery_probe.py` running the per-projector comparison, the effect-size × dimensionality sweep, and the leakage probe, and rendering the distortion/cross-talk curves (and optionally a latent-space trajectory figure per projector).
+- [x] 5.2 Run the driver and write `openspec/changes/rung2-projector-crosstalk/findings.md` with: the per-projector distortion/cross-talk table (with the per-projector `none` floor and the PCA reference), the effect-size/dimensionality sweep, the supervised-leakage result, and the SNF embedding-relative caveat.
+- [x] 5.3 State the gate decision for Rung 3: which projector(s) are clean, whether the production `concat`/`snf` path leaks magnitude→orientation, at what effect size / component count it onsets, the exact reproduction parameters (seed set, dimensions, noise/signal scale, projector settings, component grid), and the next single factor (heterogeneous multi-omic concatenation or cross-omic coupling).

--- a/scripts/projector_recovery_probe.py
+++ b/scripts/projector_recovery_probe.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Driver script for the Rung-2 projector recovery probe.
+
+Runs the per-projector comparison, the dimensionality and effect-size sweeps, and
+the supervised-leakage probe; prints the summary tables and saves the
+per-projector comparison figure. Also reports the standardize arm under
+anisotropic noise (where raw PCA degrades but standardization restores recovery).
+
+Usage
+-----
+    .venv/bin/python scripts/projector_recovery_probe.py
+    .venv/bin/python scripts/projector_recovery_probe.py \\
+        --signal_scale 5 --noise_scale 1 --n_components 2 --n_seeds 10
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import replace
+from pathlib import Path
+
+from motco.simulations.projector_recovery import (
+    ProjectorRecoveryParams,
+    plot_projector_comparison,
+    run_dimensionality_sweep,
+    run_effect_size_sweep,
+    run_leakage_probe,
+    run_projector_comparison,
+)
+
+BUILD = Path(__file__).resolve().parent.parent / "build"
+
+
+def _parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Rung-2 projector recovery probe",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("--n_features", type=int, default=50)
+    p.add_argument("--n_components", type=int, default=2)
+    p.add_argument("--signal_scale", type=float, default=5.0)
+    p.add_argument("--noise_scale", type=float, default=1.0)
+    p.add_argument("--n_samples_per_cell", type=int, default=40)
+    p.add_argument("--scale_c", type=float, default=2.0)
+    p.add_argument("--angle_theta", type=float, default=45.0)
+    p.add_argument("--anisotropy", type=float, default=1.5, help="Aniso sweep value")
+    p.add_argument("--n_seeds", type=int, default=10, help="Seeds to average over")
+    p.add_argument(
+        "--component_grid",
+        type=int,
+        nargs="+",
+        default=[2, 3, 5, 10],
+        help="Latent component counts to sweep",
+    )
+    p.add_argument(
+        "--signal_scales",
+        type=float,
+        nargs="+",
+        default=[2.0, 5.0, 8.0, 12.0],
+        help="Effect sizes to sweep",
+    )
+    p.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output path for the figure (default: build/rung2_projector_comparison.png)",
+    )
+    return p
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    base = ProjectorRecoveryParams(
+        n_features=args.n_features,
+        n_components=args.n_components,
+        signal_scale=args.signal_scale,
+        noise_scale=args.noise_scale,
+        n_samples_per_cell=args.n_samples_per_cell,
+        scale_c=args.scale_c,
+        angle_theta=args.angle_theta,
+    )
+    seeds = list(range(args.n_seeds))
+    fmt = "{:.3f}".format
+    cols = ["projector", "manipulation", "delta_mean", "delta_std", "angle_mean", "angle_std"]
+
+    print(
+        f"Projector recovery probe  |  n_features={args.n_features}  "
+        f"k={args.n_components}  signal={args.signal_scale}  noise={args.noise_scale}  "
+        f"n_per_cell={args.n_samples_per_cell}  seeds={seeds}"
+    )
+    print()
+
+    print("=== Per-projector comparison (isotropic noise) ===")
+    comp = run_projector_comparison(seeds=seeds, base_params=base)
+    print(comp[cols].to_string(index=False, float_format=fmt))
+    print()
+
+    print(f"=== Per-projector comparison (anisotropic noise = {args.anisotropy}) ===")
+    comp_aniso = run_projector_comparison(
+        seeds=seeds, base_params=replace(base, anisotropy=args.anisotropy)
+    )
+    print(comp_aniso[cols].to_string(index=False, float_format=fmt))
+    print()
+
+    print("=== Dimensionality sweep ===")
+    dim = run_dimensionality_sweep(args.component_grid, seeds=seeds, base_params=base)
+    print(
+        dim[["n_components", *cols]].to_string(index=False, float_format=fmt)
+    )
+    print()
+
+    print("=== Effect-size sweep ===")
+    eff = run_effect_size_sweep(args.signal_scales, seeds=seeds, base_params=base)
+    print(eff[["signal_scale", *cols]].to_string(index=False, float_format=fmt))
+    print()
+
+    print("=== Supervised-leakage probe (none trajectory: PLS-DA vs PCA) ===")
+    leak = run_leakage_probe(args.component_grid, seeds=seeds, base_params=base)
+    print(leak.to_string(index=False, float_format=fmt))
+    print()
+
+    print("Generating per-projector comparison figure ...")
+    fig = plot_projector_comparison(comp)
+    out = args.output
+    if out is None:
+        BUILD.mkdir(parents=True, exist_ok=True)
+        out = BUILD / "rung2_projector_comparison.png"
+    fig.savefig(out, dpi=150, bbox_inches="tight")
+    print(f"Figure saved → {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/motco/simulations/projector_recovery.py
+++ b/src/motco/simulations/projector_recovery.py
@@ -1,0 +1,606 @@
+"""Projector test bed for trajectory recovery (Rung 2).
+
+Isolates the **projector** (the dimensionality-reduction / integration step) as
+the single factor on top of the clean linear floor. The known 2-stage geometry
+(``none``/``magnitude``/``orientation``) is injected exactly as in Rung 0 into a
+clean linear feature space — the methylation **M-value frame**, so there is *no*
+``rev.logit`` distortion (Rung 1 established M-value integration as the correct
+representation). The only thing that varies versus the Rung-0 clean floor is the
+projector used before measurement:
+
+- ``pca``         — mean-centered PCA (the Rung-0/1 reference floor).
+- ``standardize`` — per-feature z-score (the production ``concat`` transform),
+                    then PCA.
+- ``plsda``       — supervised PLS-DA latent space, conditioned on the group
+                    label (``stats/pls.fit_plsda_transform``).
+- ``snf``         — graph-spectral embedding (``stats/snf``). SNF *fusion*
+                    requires ≥ 2 networks, so on this single-block test bed the
+                    arm reduces to ``get_affinity_matrix`` → ``get_spectral`` —
+                    the per-block core of the production ``snf`` path. This is a
+                    faithful single-block analogue and is documented as such.
+
+Measurement (``get_model_matrix``/``build_ls_means``/``estimate_difference`` on a
+2-group × 2-stage design, two-group contrast) is identical to Rung 0/1. Cross-talk
+is read against each projector's own ``none`` null and against the PCA floor.
+
+This is Rung 2 of a ladder. Rung 0 (``linear_recovery``) proved the linear floor
+is clean; Rung 1 (``methylation_recovery``) showed ``rev.logit`` is inverted by
+M-value integration; Rung 2 asks whether the projector itself manufactures
+magnitude→orientation cross-talk.
+
+References
+----------
+openspec/changes/rung2-projector-crosstalk/design.md
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any, Literal
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.figure import Figure
+from sklearn.decomposition import PCA
+
+from motco.simulations.linear_recovery import (
+    LinearRecoveryParams,
+)
+from motco.simulations.linear_recovery import (
+    generate_dataset as _linear_generate_dataset,
+)
+from motco.stats.design import build_ls_means, get_model_matrix
+from motco.stats.pls import fit_plsda_transform
+from motco.stats.snf import get_affinity_matrix, get_spectral
+from motco.stats.trajectory import estimate_difference
+
+__all__ = [
+    "ProjectorRecoveryError",
+    "Projector",
+    "ProjectorRecoveryParams",
+    "ProjectorRecoveryDataset",
+    "generate_dataset",
+    "project",
+    "project_and_measure",
+    "run_projector_comparison",
+    "run_dimensionality_sweep",
+    "run_effect_size_sweep",
+    "run_leakage_probe",
+    "plot_projector_comparison",
+]
+
+
+class ProjectorRecoveryError(ValueError):
+    """Raised on invalid ``ProjectorRecoveryParams``."""
+
+
+Projector = Literal["pca", "standardize", "plsda", "snf"]
+_PROJECTORS: list[Projector] = ["pca", "standardize", "plsda", "snf"]
+_MANIPULATIONS: list[Literal["none", "magnitude", "orientation"]] = [
+    "none",
+    "magnitude",
+    "orientation",
+]
+
+
+@dataclass(frozen=True)
+class ProjectorRecoveryParams:
+    """Frozen configuration for a Rung-2 projector recovery run.
+
+    Mirrors :class:`~motco.simulations.linear_recovery.LinearRecoveryParams`
+    (the geometry is injected identically) and adds the projector selector plus
+    an optional anisotropy knob and SNF affinity parameters.
+
+    Parameters
+    ----------
+    seed:
+        RNG seed for deterministic generation.
+    n_features:
+        Dimensionality of the (M-value) feature space.
+    n_samples_per_cell:
+        Samples drawn per (group, stage) cell.
+    noise_scale:
+        Base standard deviation of the Gaussian noise.
+    signal_scale:
+        ‖a_feat‖ — the magnitude of group A's feature-space step.
+    manipulation:
+        Geometric transform applied to group B's step vector.
+    scale_c:
+        Magnitude scale for the ``"magnitude"`` manipulation (step_B = c · a_feat).
+    angle_theta:
+        Rotation angle in degrees for the ``"orientation"`` manipulation.
+    n_components:
+        Number of latent components retained for measurement. Defaults to ``2``:
+        the 2-group × 2-stage signal lives in ≤ 2 dimensions, and Rung 0 showed
+        the angle null floor grows with each retained *noise* PC. The headline
+        run keeps only the signal subspace so the *projector* — not the k-noise
+        floor — is the variable under test; the dimensionality sweep probes higher.
+    projector:
+        Which projector to apply before measurement (``pca``/``standardize``/
+        ``plsda``/``snf``).
+    anisotropy:
+        Heteroscedasticity of the per-feature noise. ``0.0`` (default) is
+        isotropic (every feature shares ``noise_scale``); ``> 0`` draws
+        deterministic per-feature std multipliers ``exp(anisotropy · z_i)`` so
+        per-feature scales differ — making the ``standardize`` arm non-trivial.
+    snf_K:
+        Nearest-neighbor count for the SNF affinity matrix.
+    snf_eps:
+        Normalization factor for the SNF affinity matrix.
+    """
+
+    seed: int = 0
+    n_features: int = 50
+    n_samples_per_cell: int = 40
+    noise_scale: float = 1.0
+    signal_scale: float = 5.0
+    manipulation: Literal["none", "magnitude", "orientation"] = "none"
+    scale_c: float = 2.0
+    angle_theta: float = 45.0
+    n_components: int = 2
+    projector: Projector = "pca"
+    anisotropy: float = 0.0
+    snf_K: int = 20
+    snf_eps: float = 0.5
+
+    def as_linear(self) -> LinearRecoveryParams:
+        """Project to the Rung-0 params (shared fields) for step-construction reuse."""
+        return LinearRecoveryParams(
+            seed=self.seed,
+            n_features=self.n_features,
+            n_samples_per_cell=self.n_samples_per_cell,
+            noise_scale=self.noise_scale,
+            signal_scale=self.signal_scale,
+            manipulation=self.manipulation,
+            scale_c=self.scale_c,
+            angle_theta=self.angle_theta,
+            n_components=self.n_components,
+        )
+
+
+@dataclass
+class ProjectorRecoveryDataset:
+    """Output of :func:`generate_dataset`.
+
+    Attributes
+    ----------
+    X:
+        Feature matrix (n_samples × n_features) in the clean M-value frame.
+    metadata:
+        Sample metadata with ``"group"`` (A/B) and ``"stage"`` (0/1) columns,
+        row-aligned with ``X``.
+    step_A:
+        Ground-truth feature-space step for group A (μ_{A,1} − μ_{A,0}).
+    step_B:
+        Ground-truth feature-space step for group B.
+    """
+
+    X: pd.DataFrame
+    metadata: pd.DataFrame
+    step_A: np.ndarray
+    step_B: np.ndarray
+
+
+# ---------------------------------------------------------------------------
+# Validation and generation
+# ---------------------------------------------------------------------------
+
+
+def _validate(p: ProjectorRecoveryParams) -> None:
+    if p.n_samples_per_cell < 2:
+        raise ProjectorRecoveryError("n_samples_per_cell must be >= 2")
+    if p.n_components < 2:
+        raise ProjectorRecoveryError("n_components must be >= 2")
+    if p.n_components > p.n_features:
+        raise ProjectorRecoveryError(
+            f"n_components ({p.n_components}) must be <= n_features ({p.n_features})"
+        )
+    n_samples = 4 * p.n_samples_per_cell
+    if p.n_components >= n_samples:
+        raise ProjectorRecoveryError(
+            f"n_components ({p.n_components}) must be < n_samples ({n_samples})"
+        )
+    if p.noise_scale <= 0:
+        raise ProjectorRecoveryError("noise_scale must be > 0")
+    if p.signal_scale <= 0:
+        raise ProjectorRecoveryError("signal_scale must be > 0")
+    if p.anisotropy < 0:
+        raise ProjectorRecoveryError("anisotropy must be >= 0")
+    if p.manipulation not in ("none", "magnitude", "orientation"):
+        raise ProjectorRecoveryError(
+            f"manipulation must be 'none', 'magnitude', or 'orientation'; "
+            f"got {p.manipulation!r}"
+        )
+    if p.projector not in _PROJECTORS:
+        raise ProjectorRecoveryError(
+            f"projector must be one of {_PROJECTORS}; got {p.projector!r}"
+        )
+    if p.projector == "snf":
+        if p.snf_K < 1 or p.snf_K >= n_samples:
+            raise ProjectorRecoveryError(
+                f"snf_K ({p.snf_K}) must be in [1, n_samples-1] (n_samples={n_samples})"
+            )
+        if p.snf_eps <= 0:
+            raise ProjectorRecoveryError("snf_eps must be > 0")
+
+
+def generate_dataset(params: ProjectorRecoveryParams) -> ProjectorRecoveryDataset:
+    """Generate a clean linear test-bed dataset with known trajectory geometry.
+
+    The per-group steps (``step_A``, ``step_B``) are constructed by the Rung-0
+    generator (reused unchanged), so the injected geometry is identical to Rung 0.
+    Means are ``μ_{g,0} = 0`` and ``μ_{g,1} = step_g``; samples are drawn
+    ``x = μ + N(0, Σ)`` where ``Σ`` is diagonal with per-feature std
+    ``noise_scale · exp(anisotropy · z_i)`` (isotropic when ``anisotropy = 0``).
+
+    Parameters
+    ----------
+    params:
+        Generation configuration.
+    """
+    _validate(params)
+
+    # Reuse Rung-0 step construction (deterministic given seed); ignore its X.
+    lin = _linear_generate_dataset(params.as_linear())
+    step_A, step_B = lin.step_A, lin.step_B
+
+    p = params.n_features
+    n = params.n_samples_per_cell
+    mu: dict[tuple[str, str], np.ndarray] = {
+        ("A", "0"): np.zeros(p),
+        ("A", "1"): step_A,
+        ("B", "0"): np.zeros(p),
+        ("B", "1"): step_B,
+    }
+
+    rng = np.random.default_rng(params.seed)
+    if params.anisotropy > 0:
+        feat_scale = np.exp(params.anisotropy * rng.standard_normal(p))
+    else:
+        feat_scale = np.ones(p)
+    noise_std = params.noise_scale * feat_scale  # per-feature std
+
+    rows: list[np.ndarray] = []
+    meta_rows: list[tuple[str, str]] = []
+    for group in ("A", "B"):
+        for stage in ("0", "1"):
+            noise = rng.standard_normal((n, p)) * noise_std
+            rows.append(mu[(group, stage)] + noise)
+            meta_rows.extend([(group, stage)] * n)
+
+    X_arr = np.vstack(rows)
+    X_df = pd.DataFrame(X_arr, columns=[f"f{i}" for i in range(p)])
+    metadata = pd.DataFrame(meta_rows, columns=["group", "stage"])
+
+    return ProjectorRecoveryDataset(
+        X=X_df, metadata=metadata, step_A=step_A, step_B=step_B
+    )
+
+
+# ---------------------------------------------------------------------------
+# Projectors (uniform (X, y) → Y contract)
+# ---------------------------------------------------------------------------
+
+
+def project(
+    dataset: ProjectorRecoveryDataset, params: ProjectorRecoveryParams
+) -> pd.DataFrame:
+    """Map the feature matrix to an ``n_components`` latent matrix.
+
+    All four projectors share the same contract: take the
+    ``(n_samples × n_features)`` feature matrix (and, for the supervised arm, the
+    group label) and return an ``(n_samples × n_components)`` latent ``DataFrame``
+    whose rows are aligned with ``dataset.metadata``.
+
+    - ``pca``         — ``PCA`` on mean-centered features (sklearn centers
+                        internally); reproduces the Rung-0 floor exactly.
+    - ``standardize`` — per-feature z-score (``std == 0 → 1``, matching
+                        ``evaluation.py:_concat_integration``) then ``PCA``.
+    - ``plsda``       — ``fit_plsda_transform`` with the group label.
+    - ``snf``         — ``get_affinity_matrix`` → ``get_spectral`` (single-block;
+                        SNF fusion needs ≥ 2 networks and is a no-op for one block).
+    """
+    X = dataset.X.to_numpy(dtype=float)
+    k = params.n_components
+
+    if params.projector == "pca":
+        Y = PCA(n_components=k).fit_transform(X)
+    elif params.projector == "standardize":
+        mean = X.mean(axis=0, keepdims=True)
+        std = X.std(axis=0, keepdims=True)
+        std[std == 0.0] = 1.0
+        Xz = (X - mean) / std
+        Y = PCA(n_components=k).fit_transform(Xz)
+    elif params.projector == "plsda":
+        y = dataset.metadata["group"].astype(str).to_numpy()
+        Y = fit_plsda_transform(X, y, n_components=k)
+    else:  # snf — single-block: affinity → spectral (fusion mooted for one block)
+        aff = get_affinity_matrix([X], K=params.snf_K, eps=params.snf_eps)[0]
+        Y = get_spectral(aff, n_components=k)
+
+    return pd.DataFrame(
+        np.asarray(Y, dtype=float),
+        columns=[f"comp{i + 1}" for i in range(k)],
+        index=dataset.metadata.index,
+    )
+
+
+def _measure_projected(
+    Y: pd.DataFrame, metadata: pd.DataFrame
+) -> tuple[float, float]:
+    """Measure group-A-vs-B delta/angle on a projected outcome matrix.
+
+    Builds the 2-group × 2-stage design and two-group contrast and calls
+    ``estimate_difference`` — identical to the Rung-0/1 measurement path.
+    """
+    model_matrix = get_model_matrix(
+        metadata, group_col="group", level_col="stage", full=True
+    )
+    g_levels = sorted(metadata["group"].astype(str).unique().tolist())
+    l_levels = sorted(metadata["stage"].astype(str).unique().tolist())
+    ls_means = build_ls_means(g_levels, l_levels, full=True)
+    n_l = len(l_levels)
+    contrast = [list(range(i * n_l, (i + 1) * n_l)) for i in range(len(g_levels))]
+    deltas, angles, _ = estimate_difference(Y, model_matrix, ls_means, contrast)
+    return float(deltas[0, 1]), float(angles[0, 1])
+
+
+def project_and_measure(
+    dataset: ProjectorRecoveryDataset, params: ProjectorRecoveryParams
+) -> tuple[float, float, pd.DataFrame]:
+    """Project with the selected projector and measure delta/angle.
+
+    Returns
+    -------
+    delta : float
+        Group-A vs Group-B magnitude difference (projector-relative for ``snf``).
+    angle : float
+        Group-A vs Group-B direction difference (degrees).
+    Y : pd.DataFrame
+        Projected outcome matrix (n_samples × n_components).
+    """
+    Y = project(dataset, params)
+    delta, angle = _measure_projected(Y, dataset.metadata)
+    return delta, angle, Y
+
+
+# ---------------------------------------------------------------------------
+# Drivers / sweeps
+# ---------------------------------------------------------------------------
+
+
+def _measure_over_seeds(
+    base_params: ProjectorRecoveryParams,
+    manip: Literal["none", "magnitude", "orientation"],
+    seeds: list[int],
+    **overrides: Any,
+) -> tuple[list[float], list[float]]:
+    deltas: list[float] = []
+    angles: list[float] = []
+    for seed in seeds:
+        params = replace(base_params, seed=seed, manipulation=manip, **overrides)
+        dataset = generate_dataset(params)
+        delta, angle, _ = project_and_measure(dataset, params)
+        deltas.append(delta)
+        angles.append(angle)
+    return deltas, angles
+
+
+def run_projector_comparison(
+    seeds: list[int] | None = None,
+    base_params: ProjectorRecoveryParams | None = None,
+    projectors: list[Projector] | None = None,
+) -> pd.DataFrame:
+    """Compare projectors on identical geometry over the seed set.
+
+    Returns a tidy DataFrame with one row per (projector, manipulation):
+    ``projector``, ``manipulation``, and the mean ± SD of ``delta``/``angle``
+    over ``seeds``. The ``none`` rows give each projector's null floor; the
+    ``pca`` rows are the cross-projector reference.
+
+    Parameters
+    ----------
+    seeds:
+        RNG seeds to average over. Defaults to ``list(range(10))``.
+    base_params:
+        Template configuration. Defaults to ``ProjectorRecoveryParams()``.
+    projectors:
+        Projectors to compare. Defaults to all four.
+    """
+    if seeds is None:
+        seeds = list(range(10))
+    if base_params is None:
+        base_params = ProjectorRecoveryParams()
+    if projectors is None:
+        projectors = list(_PROJECTORS)
+
+    rows = []
+    for projector in projectors:
+        params = replace(base_params, projector=projector)
+        for manip in _MANIPULATIONS:
+            deltas, angles = _measure_over_seeds(params, manip, seeds)
+            rows.append(
+                {
+                    "projector": projector,
+                    "manipulation": manip,
+                    "delta_mean": float(np.mean(deltas)),
+                    "delta_std": float(np.std(deltas)),
+                    "angle_mean": float(np.mean(angles)),
+                    "angle_std": float(np.std(angles)),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def run_dimensionality_sweep(
+    n_components_grid: list[int],
+    seeds: list[int] | None = None,
+    base_params: ProjectorRecoveryParams | None = None,
+    projectors: list[Projector] | None = None,
+) -> pd.DataFrame:
+    """Sweep retained latent dimensionality per projector and manipulation.
+
+    Locates whether any projector-induced cross-talk is a dimensionality
+    artifact (too few/many retained directions) or intrinsic. Same column
+    layout as :func:`run_projector_comparison` plus an ``n_components`` column.
+    """
+    if seeds is None:
+        seeds = list(range(10))
+    if base_params is None:
+        base_params = ProjectorRecoveryParams()
+    if projectors is None:
+        projectors = list(_PROJECTORS)
+
+    rows = []
+    for k in n_components_grid:
+        for projector in projectors:
+            params = replace(base_params, projector=projector, n_components=k)
+            for manip in _MANIPULATIONS:
+                deltas, angles = _measure_over_seeds(params, manip, seeds)
+                rows.append(
+                    {
+                        "n_components": int(k),
+                        "projector": projector,
+                        "manipulation": manip,
+                        "delta_mean": float(np.mean(deltas)),
+                        "delta_std": float(np.std(deltas)),
+                        "angle_mean": float(np.mean(angles)),
+                        "angle_std": float(np.std(angles)),
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def run_effect_size_sweep(
+    signal_scales: list[float],
+    seeds: list[int] | None = None,
+    base_params: ProjectorRecoveryParams | None = None,
+    projectors: list[Projector] | None = None,
+) -> pd.DataFrame:
+    """Sweep effect size (``signal_scale``) per projector and manipulation.
+
+    Same column layout as :func:`run_projector_comparison` plus a
+    ``signal_scale`` column. Locates the onset of any projector-induced
+    distortion as the injected step grows.
+    """
+    if seeds is None:
+        seeds = list(range(10))
+    if base_params is None:
+        base_params = ProjectorRecoveryParams()
+    if projectors is None:
+        projectors = list(_PROJECTORS)
+
+    rows = []
+    for scale in signal_scales:
+        for projector in projectors:
+            params = replace(base_params, projector=projector, signal_scale=scale)
+            for manip in _MANIPULATIONS:
+                deltas, angles = _measure_over_seeds(params, manip, seeds)
+                rows.append(
+                    {
+                        "signal_scale": float(scale),
+                        "projector": projector,
+                        "manipulation": manip,
+                        "delta_mean": float(np.mean(deltas)),
+                        "delta_std": float(np.std(deltas)),
+                        "angle_mean": float(np.mean(angles)),
+                        "angle_std": float(np.std(angles)),
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def run_leakage_probe(
+    n_components_grid: list[int],
+    seeds: list[int] | None = None,
+    base_params: ProjectorRecoveryParams | None = None,
+) -> pd.DataFrame:
+    """Supervised-leakage probe: ``none`` trajectory under PLS-DA vs PCA.
+
+    PLS-DA conditions the projection on the group label, so it can manufacture
+    group-aligned structure even when the two groups have *identical* (``none``)
+    trajectories. This probe measures the ``none`` ``delta``/``angle`` under both
+    ``plsda`` and ``pca`` across a component grid (larger ``n_components`` relative
+    to the sample size stresses the leakage), so any inflation of the PLS-DA null
+    above the PCA floor is exposed.
+
+    Returns one row per (n_components, projector ∈ {pca, plsda}) with the ``none``
+    ``delta``/``angle`` mean ± SD.
+    """
+    if seeds is None:
+        seeds = list(range(10))
+    if base_params is None:
+        base_params = ProjectorRecoveryParams()
+
+    rows = []
+    for k in n_components_grid:
+        for projector in ("pca", "plsda"):
+            params = replace(base_params, projector=projector, n_components=k)
+            deltas, angles = _measure_over_seeds(params, "none", seeds)
+            rows.append(
+                {
+                    "n_components": int(k),
+                    "projector": projector,
+                    "delta_mean": float(np.mean(deltas)),
+                    "delta_std": float(np.std(deltas)),
+                    "angle_mean": float(np.mean(angles)),
+                    "angle_std": float(np.std(angles)),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Visualization
+# ---------------------------------------------------------------------------
+
+
+def plot_projector_comparison(comparison: pd.DataFrame) -> Figure:
+    """Grouped bar chart of delta/angle per projector for each manipulation.
+
+    Two panels (delta, angle); x-axis grouped by projector, bars per
+    manipulation, with the ``none`` null floor visible per projector.
+
+    Parameters
+    ----------
+    comparison:
+        Output of :func:`run_projector_comparison`.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    """
+    projectors = list(dict.fromkeys(comparison["projector"]))
+    x = np.arange(len(projectors))
+    width = 0.25
+    colors = {"none": "0.6", "magnitude": "C0", "orientation": "C1"}
+
+    fig, axes = plt.subplots(1, 2, figsize=(13, 5))
+    for stat, ax in zip(("delta", "angle"), axes):
+        for j, manip in enumerate(_MANIPULATIONS):
+            sub = comparison[comparison["manipulation"] == manip].set_index("projector")
+            means = [sub.loc[p, f"{stat}_mean"] for p in projectors]
+            errs = [sub.loc[p, f"{stat}_std"] for p in projectors]
+            ax.bar(
+                x + (j - 1) * width,
+                means,
+                width,
+                yerr=errs,
+                capsize=3,
+                color=colors[manip],
+                label=manip,
+            )
+        ax.set_xticks(x)
+        ax.set_xticklabels(projectors)
+        ax.set_ylabel(f"measured {stat}" + ("  (degrees)" if stat == "angle" else ""))
+        ax.set_title(f"{stat} by projector")
+        ax.legend(title="manipulation", fontsize=8)
+
+    fig.suptitle(
+        "Rung 2 — Projector recovery: delta/angle by projector",
+        fontsize=12,
+        y=1.02,
+    )
+    fig.tight_layout()
+    return fig

--- a/tests/test_projector_recovery.py
+++ b/tests/test_projector_recovery.py
@@ -1,0 +1,176 @@
+"""Tests for the Rung-2 projector recovery test bed."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from motco.simulations.projector_recovery import (
+    ProjectorRecoveryError,
+    ProjectorRecoveryParams,
+    generate_dataset,
+    project,
+    project_and_measure,
+    run_leakage_probe,
+    run_projector_comparison,
+)
+
+# Clean linear floor: good SNR, signal in ≤ 2 dims, isotropic noise so the only
+# variable under test is the projector. Mirrors the Rung-0 defaults.
+_BASE = ProjectorRecoveryParams(
+    seed=0,
+    n_features=50,
+    n_samples_per_cell=40,
+    noise_scale=1.0,
+    signal_scale=5.0,
+    n_components=2,
+)
+
+_PROJECTORS = ["pca", "standardize", "plsda", "snf"]
+
+
+# ---------------------------------------------------------------------------
+# 4.1  Determinism, structure, reused geometry
+# ---------------------------------------------------------------------------
+
+
+def test_deterministic_same_seed():
+    d1, a1, _ = project_and_measure(generate_dataset(_BASE), _BASE)
+    d2, a2, _ = project_and_measure(generate_dataset(replace(_BASE)), _BASE)
+    assert (d1, a1) == (d2, a2)
+
+
+def test_deterministic_snf_same_seed():
+    p = replace(_BASE, projector="snf", manipulation="magnitude", seed=3)
+    r1 = project_and_measure(generate_dataset(p), p)[:2]
+    r2 = project_and_measure(generate_dataset(p), p)[:2]
+    assert r1 == r2
+
+
+def test_different_seeds_differ():
+    d1 = generate_dataset(_BASE)
+    d2 = generate_dataset(replace(_BASE, seed=99))
+    assert not np.allclose(d1.X.to_numpy(), d2.X.to_numpy())
+
+
+def test_exactly_two_stages():
+    d = generate_dataset(_BASE)
+    assert sorted(d.metadata["stage"].unique().tolist()) == ["0", "1"]
+    assert sorted(d.metadata["group"].unique().tolist()) == ["A", "B"]
+
+
+def test_reuses_rung0_geometry():
+    # step_A / step_B are the Rung-0 construction: magnitude scales A's step by c.
+    p = replace(_BASE, manipulation="magnitude")
+    d = generate_dataset(p)
+    np.testing.assert_allclose(d.step_B, p.scale_c * d.step_A, rtol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# 4.2  PCA arm reproduces the Rung-0 clean floor
+# ---------------------------------------------------------------------------
+
+
+def test_pca_magnitude_moves_delta_only():
+    none_d, none_a, _ = project_and_measure(
+        generate_dataset(replace(_BASE, projector="pca", manipulation="none")),
+        replace(_BASE, projector="pca", manipulation="none"),
+    )
+    p = replace(_BASE, projector="pca", manipulation="magnitude")
+    d, a, _ = project_and_measure(generate_dataset(p), p)
+    # delta well above the null floor; angle stays near the none floor.
+    assert d > 10 * none_d
+    assert a < none_a + 3.0
+
+
+def test_pca_orientation_moves_angle_only():
+    none = replace(_BASE, projector="pca", manipulation="none")
+    none_d, _, _ = project_and_measure(generate_dataset(none), none)
+    p = replace(_BASE, projector="pca", manipulation="orientation")
+    d, a, _ = project_and_measure(generate_dataset(p), p)
+    # angle recovers the injected 45° within tolerance; delta near the null floor.
+    assert abs(a - _BASE.angle_theta) < 10.0
+    assert d < none_d + 1.0
+
+
+# ---------------------------------------------------------------------------
+# 4.3  Projector contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("projector", _PROJECTORS)
+@pytest.mark.parametrize("manipulation", ["none", "magnitude", "orientation"])
+def test_projector_contract(projector, manipulation):
+    p = replace(_BASE, projector=projector, manipulation=manipulation)
+    ds = generate_dataset(p)
+    Y = project(ds, p)
+    n_samples = 4 * p.n_samples_per_cell
+    assert Y.shape == (n_samples, p.n_components)
+    assert np.all(np.isfinite(Y.to_numpy()))
+    delta, angle, _ = project_and_measure(ds, p)
+    assert np.isfinite(delta) and np.isfinite(angle)
+
+
+def test_standardize_recovers_under_anisotropy():
+    # Under heteroscedastic noise, raw PCA loses the signal to large-variance
+    # noise directions, but per-feature standardization restores clean recovery.
+    aniso = dict(anisotropy=1.5, manipulation="orientation")
+    pca = replace(_BASE, projector="pca", **aniso)
+    std = replace(_BASE, projector="standardize", **aniso)
+    _, pca_angle, _ = project_and_measure(generate_dataset(pca), pca)
+    _, std_angle, _ = project_and_measure(generate_dataset(std), std)
+    # standardize recovers the injected orientation; raw PCA does not.
+    assert abs(std_angle - _BASE.angle_theta) < 10.0
+    assert abs(pca_angle - _BASE.angle_theta) > 30.0
+
+
+# ---------------------------------------------------------------------------
+# 4.4  Supervised-leakage probe
+# ---------------------------------------------------------------------------
+
+
+def test_leakage_probe_reports_both_references():
+    probe = run_leakage_probe([2, 4], seeds=[0, 1, 2], base_params=_BASE)
+    projectors = set(probe["projector"])
+    assert projectors == {"pca", "plsda"}
+    assert set(probe["n_components"]) == {2, 4}
+    # Both references report a finite null delta/angle for each component count.
+    assert np.all(np.isfinite(probe["delta_mean"]))
+    assert np.all(np.isfinite(probe["angle_mean"]))
+
+
+def test_projector_comparison_has_null_floor_and_reference():
+    comp = run_projector_comparison(seeds=[0, 1, 2], base_params=_BASE)
+    # one row per (projector, manipulation)
+    assert len(comp) == len(_PROJECTORS) * 3
+    assert set(comp["projector"]) == set(_PROJECTORS)
+    # PCA magnitude separates cleanly from its own none floor (the reference).
+    pca = comp[comp["projector"] == "pca"].set_index("manipulation")
+    assert pca.loc["magnitude", "delta_mean"] > 5 * pca.loc["none", "delta_mean"]
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_validation_rejects_bad_projector():
+    with pytest.raises(ProjectorRecoveryError):
+        generate_dataset(replace(_BASE, projector="bogus"))  # type: ignore[arg-type]
+
+
+def test_validation_rejects_too_few_samples():
+    with pytest.raises(ProjectorRecoveryError):
+        generate_dataset(replace(_BASE, n_samples_per_cell=1))
+
+
+def test_validation_rejects_components_over_features():
+    with pytest.raises(ProjectorRecoveryError):
+        generate_dataset(replace(_BASE, n_components=999))
+
+
+def test_validation_rejects_negative_anisotropy():
+    with pytest.raises(ProjectorRecoveryError):
+        generate_dataset(replace(_BASE, anisotropy=-1.0))


### PR DESCRIPTION
## Summary

Third rung of the trajectory-recovery diagnostic ladder. Rung 0 (#19) proved the linear floor is clean under mean-centered PCA; Rung 1 (#20) showed methylation `rev.logit` is inverted by M-value integration (not a standing cross-talk source). **Rung 2 isolates the projector** — the dimensionality-reduction / integration step — as the next single factor.

The known 2-stage geometry (`none`/`magnitude`/`orientation`) is injected into a clean linear feature space (the methylation **M-value frame**, so no `rev.logit` distortion), then `delta`/`angle` are measured through four selectable projectors with the estimator path held identical to Rung 0/1. Cross-talk is read against each projector's own `none` null and against the PCA floor; a second pass under heteroscedastic per-feature noise stresses where they diverge.

## Projectors compared

- **`pca`** — mean-centered PCA (the Rung-0/1 reference floor).
- **`standardize`** — per-feature z-score (the production `concat` transform, `evaluation.py:_concat_integration`), then PCA.
- **`plsda`** — supervised PLS-DA latent space, conditioned on the group label (`stats/pls.fit_plsda_transform`).
- **`snf`** — graph-spectral embedding (`stats/snf`). SNF fusion needs ≥2 networks, so the single-block arm reduces to `get_affinity_matrix → get_spectral` — the per-block core of the production `snf` path.

## Findings

| projector | orientation faithful? | magnitude→angle cross-talk? | robust to feature-scale heterogeneity? | verdict |
|---|:---:|:---:|:---:|---|
| **pca** (raw) | yes (isotropic only) | no (isotropic only) | **no** — collapses under anisotropy | conditional |
| **standardize** (`concat`) | **yes** | **no** | **yes** | **clean** |
| **plsda** | **no** (110°+) | in null, at low k | yes | **leaks** |
| **snf** | no | **yes (~70°)** | no | **leaks** |

- **Standardize (the `concat` projector) is clean:** preserves orientation, introduces no magnitude→orientation cross-talk, and *rescues* raw PCA's collapse under heteroscedastic noise (a concrete justification for why the production path z-scores). Its only effect is a uniform magnitude rescale — it changes "how long," never "which way."
- **PLS-DA leaks:** a two-class label defines only one reliable discriminant axis, so retained higher axes scramble orientation (110°+) and inflate/destabilize the null at low component counts.
- **SNF leaks:** single-block spectral embedding turns a pure magnitude change into ~70° of spurious angle, with embedding-relative magnitudes that collapse under large effects.

## Gate decision & ladder reframing

On a **single** clean block the production `concat` path is faithful, so the specificity-study cross-talk is **not** explained by single-block standardization. The next untested factor on the clean path is **heterogeneous multi-omic concatenation** — the real pipeline z-scores and concatenates three omic blocks of different dimensionality and scale, and unequal blocks can tilt the pooled PCA toward the larger/most-correlated block. **Decision: Rung 3 = heterogeneous multi-omic concatenation.** SNF is recorded as a known-leaky projector and PLS-DA as out-of-scope for geometry — both settled here.

## Changes

- `src/motco/simulations/projector_recovery.py` — test bed: generation (reuses Rung-0 geometry in M-space, optional anisotropy knob), the four-projector `(X, y) → Y` contract, measurement, per-projector comparison + dimensionality/effect-size sweeps + supervised-leakage probe, plotting.
- `tests/test_projector_recovery.py` — 26 fast tests.
- `scripts/projector_recovery_probe.py` — driver.
- `openspec/changes/rung2-projector-crosstalk/` — proposal, design, tasks, spec, findings.

## Test plan

- [x] `ruff check src/ tests/`
- [x] `mypy src/motco/` — clean (32 files)
- [x] `pytest -m "not slow"` — 292 passed, 2 skipped (no R), 7 slow deselected
- [x] `openspec validate rung2-projector-crosstalk --strict`

🤖 Generated with [Claude Code](https://claude.com/claude-code)