### PR TITLE
Rung 3: trajectory cross-talk through the production latent spaces

### DIFF
--- a/openspec/changes/rung3-latent-space-crosstalk/.openspec.yaml
+++ b/openspec/changes/rung3-latent-space-crosstalk/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-15

--- a/openspec/changes/rung3-latent-space-crosstalk/design.md
+++ b/openspec/changes/rung3-latent-space-crosstalk/design.md
@@ -1,0 +1,34 @@
+# Design — Rung 3: cross-talk through the production latent spaces
+
+## Context
+
+Rungs 0–2 used a generator-free test bed (known geometry injected into a clean feature space) to isolate factors abstractly. Rung 3 deliberately switches back to the **full production path**: the semi-synthetic generator → integration (latent space) → `estimate_difference` → RRPP rejection rates, as instrumented by `specificity.py`. The reason is that the cross-talk observation originated *there*, and Rung 2 has now characterized every upstream factor — what remains untested end-to-end is whether the real PLS latent space reproduces or removes the cross-talk on the actual generator.
+
+## What the study measures
+
+For each trajectory mode (`magnitude`, `orientation`, `shape`, `none`) the existing `evaluate_mode_specificity` already reports, over replicates, the **per-statistic RRPP rejection rate** (`delta`/`angle`/`shape` at `alpha`) plus the **group-in-stage fraction** (how much of the injected group signal lies in the stage subspace). A *specific* construction rejects predominantly on its target statistic (`magnitude`→`delta`, `orientation`→`angle`, `shape`→`shape`); cross-talk shows up as off-target rejections. Rung 3 runs this unchanged instrument through three latent spaces and compares.
+
+## Key decisions
+
+### Reuse the instrument; only add a latent-space selector
+`evaluate_mode_specificity`/`characterize_two_stage` currently hard-default to `concat`. We add `integration_method` + `integration_params` (default `concat`, so existing callers and tests are unchanged) and forward them to **both** the RRPP evaluation and the `_group_in_stage_fraction` projection (the projection must be measured in the *same* latent space, or the diagnostic is incoherent). No change to the rejection-rate contract.
+
+### Three latent spaces, matched everything else
+Run `concat` (baseline reference), `pls` (production, stage-conditioned, double-CV-sized), and `snf` (production, graph-spectral) on **identical** seeds, effect size, `p_dmp`, `n_stages`, and permutation count. The only swept factor is the latent space — keeping the single-factor discipline of the ladder.
+
+### Modest PLS CV knobs
+PLS integration runs `plsda_doubleCV` once per replicate (not per permutation — integration builds the latent matrix once, RRPP permutes its residuals). With ~10 replicates × 4 modes that is ~40 double-CV fits; the driver passes small CV knobs (`n_repeats`, `cv2_splits`, `cv1_splits`, `max_components`) so the whole study runs in minutes locally. Effective CV params are recorded.
+
+## Hypotheses (from Rung 2)
+
+- **PLS:** clean `none` null (no spurious `angle`/`delta` rejection) but **attenuated orientation power** — `orientation`→`angle` rejection lower than under `concat`, because the stage-conditioned latent space compresses the group-specific direction. `magnitude`→`delta` should remain strong.
+- **SNF:** magnitude↔angle cross-talk (Rung 2's ~70° leak) should surface as `magnitude` producing off-target `angle` rejections and/or unstable rates.
+- **concat:** the existing baseline behavior (the cross-talk originally observed) reproduced — the reference against which PLS/SNF are read.
+
+The point of the rung is to confirm or refute these on the *real generator with RRPP*, where multi-omic coupling and the methylation nonlinearity are present (unlike the clean test bed).
+
+## Risks / alternatives
+
+- **Cost** — mitigated by configurable, modest CV knobs; documented.
+- **Confounds** — the production path includes generator coupling + `rev.logit`, which the test bed excluded. That is intentional here (we want the end-to-end answer), but it means a difference vs the test bed cannot be attributed to the projector alone; the findings must read PLS/SNF *relative to the concat baseline on the same generator*, not against the Rung-2 test-bed numbers.
+- **Alternative** — extend the grid/power study instead of the specificity instrument. Rejected for now: the specificity rejection-rate instrument is the lighter, purpose-built diagnostic and already encodes the target-statistic logic; a full power grid is a later step if the specificity comparison warrants it.

--- a/openspec/changes/rung3-latent-space-crosstalk/findings.md
+++ b/openspec/changes/rung3-latent-space-crosstalk/findings.md
@@ -1,0 +1,91 @@
+## Rung 3 — Cross-talk through the production latent spaces: Findings
+
+### What this experiment does
+
+Rungs 0–2 isolated the cross-talk factors on a generator-free test bed. Rung 3 switches to the **full production path** — semi-synthetic generator → integration (latent space) → `estimate_difference` → RRPP rejection rates, via `specificity.py` — and runs the dominant-specificity study through three latent spaces on identical seeds, effect size, stages, and permutation count. The only swept factor is the latent space:
+
+- **`concat`** — the standardized-feature-concatenation **baseline** (what the specificity study has always used).
+- **`snf`** — the graph-spectral production latent space.
+- **`pls`** — the stage-conditioned, double-CV-sized production latent space (added in PR #23).
+
+A *specific* construction rejects predominantly on its target statistic (`magnitude`→`delta`, `orientation`→`angle`, `shape`→`shape`); off-target rejections are cross-talk. The group-in-stage fraction (GIS) reports how much of the injected group signal lies in the stage subspace of each latent space.
+
+---
+
+### Reproduction parameters
+
+| Parameter | Value |
+|-----------|-------|
+| `n_replicates` | 6 |
+| `permutations` | 49 |
+| `n_samples` | 160 |
+| `n_stages` | 4 |
+| `effect_size` | 1.0 |
+| `p_dmp` | 0.2 |
+| PLS CV | `n_repeats=2, cv2=4, cv1=3, max_components=8` |
+| Integration | serial (`n_jobs=1`) |
+
+```bash
+.venv/bin/python scripts/latent_space_crosstalk_probe.py \
+    --reps 6 --perms 49 --n-samples 160 --n-stages 4 --n-jobs 1 \
+    --pls-repeats 2 --pls-cv2 4 --pls-cv1 3 --pls-max-components 8
+```
+
+**Resolution caveat.** 6 replicates → rejection-rate granularity of 1/6 ≈ 0.17; values of 0.17/0.33/0.50 are 1/6, 2/6, 3/6. These are *qualitative direction* reads, not power estimates. Read `pls`/`snf` relative to the `concat` baseline *on the same generator* — not against the Rung-2 test-bed numbers (the production path also carries generator coupling + `rev.logit`).
+
+---
+
+### Per-statistic rejection rates by latent space
+
+| latent space | mode | delta | angle | shape | group-in-stage |
+|--------------|------|-------|-------|-------|----------------|
+| concat (baseline) | `none` | 0.17 | 0.00 | 0.17 | 0.14 |
+| concat (baseline) | `magnitude` | **1.00** | 0.00 | 1.00 | 0.09 |
+| concat (baseline) | `orientation` | 0.17 | **0.33** | 1.00 | 0.07 |
+| concat (baseline) | `shape` | 1.00 | 0.67 | **1.00** | 0.18 |
+| snf | `none` | 0.00 | 0.00 | 0.33 | 0.43 |
+| snf | `magnitude` | **0.00** | 0.00 | 1.00 | 0.15 |
+| snf | `orientation` | 0.00 | **0.00** | 1.00 | 0.53 |
+| snf | `shape` | 0.00 | 0.00 | **1.00** | 0.53 |
+| pls | `none` | 0.17 | 0.00 | 0.00 | 1.00 |
+| pls | `magnitude` | **1.00** | 0.17 | 0.00 | 1.00 |
+| pls | `orientation` | 0.33 | **0.33** | 1.00 | 1.00 |
+| pls | `shape` | 1.00 | 0.50 | **1.00** | 1.00 |
+
+---
+
+### Finding 1 — The feared "magnitude → orientation" cross-talk is essentially absent; the real cross-talk is the **shape statistic**
+
+Across *all three* latent spaces the magnitude→`angle` bleed is small (concat 0.00, snf 0.00, pls 0.17). The dominant off-target signal is **`shape`**:
+
+- `magnitude` triggers `shape` (concat 1.00, snf 1.00) — a pure size change reads as a shape change.
+- `orientation` triggers `shape` (1.00 in *every* latent space).
+- `shape` triggers `delta` (concat 1.00, pls 1.00) and `angle` (concat 0.67, pls 0.50) — the shape mode is the least specific construction.
+
+So the cross-talk the ladder has been chasing is predominantly **Procrustes-`shape` promiscuity**, and it is *largely invariant to the latent space* (it appears under concat, snf, and pls alike). That points the next rung at the `shape` estimator/test, not the projector.
+
+### Finding 2 — PLS **removes** the magnitude→shape contamination (the part that *was* a baseline artifact)
+
+The one cross-talk that the latent space *does* fix: under `concat`, a pure `magnitude` change rejects `shape` at 1.00; under **`pls` it drops to 0.00** (and `none`→`shape` also goes 0.17 → 0.00). The stage-conditioned, low-dimensional PLS space strips the size-driven shape artifact, giving a clean `magnitude`→`delta`=1.00 with `shape`=0.00. This is the concrete payoff of measuring in a real latent space rather than the concat baseline — but it only cures the *magnitude*-side shape contamination; `orientation`→`shape` and `shape`→`delta`/`angle` persist under PLS.
+
+PLS otherwise matches the Rung-2 prediction: clean `none` null (`angle`=0.00, `shape`=0.00), strong `magnitude`→`delta` (1.00), only a mild `magnitude`→`angle` bleed (0.17). Orientation power is modest (`angle`=0.33, same as concat) — the predicted compression shows as weak-but-not-absent orientation sensitivity.
+
+### Finding 3 — SNF has **no `delta`/`angle` power** and a saturated/anti-conservative `shape`
+
+Under `snf`, `delta` and `angle` reject at 0.00 for *every* mode (including the true `magnitude`/`orientation` movers), while `shape` rejects at 1.00 everywhere — and even `none`→`shape`=0.33 (anti-conservative). The spectral embedding's metric is not commensurable with the injected size/orientation geometry (Rung 2's leak, end-to-end): it cannot detect magnitude or orientation at all, and its shape test is saturated. **SNF is unusable as the measurement latent space for `delta`/`angle`.**
+
+### Finding 4 — Structural: PLS confines the group signal to the stage subspace (GIS = 1.00)
+
+The group-in-stage fraction is ~0.1 under `concat` (the injected group difference is mostly *orthogonal* to the stage subspace in full feature space) but **1.00 under `pls`** for every mode. This is by construction: PLS builds the space from the stage label, so any measured group difference necessarily lies in the stage-relevant subspace. This is a double-edged property — it focuses the test on disease-relevant variation, but it also means group variation *orthogonal* to the stage axis is discarded before measurement. Worth keeping in view when interpreting PLS-space power.
+
+---
+
+### Gate decision
+
+1. **The projector is not the dominant cross-talk source.** The magnitude→orientation leak that motivated the ladder is essentially absent on the real generator (≤0.17 everywhere). The dominant cross-talk is the **`shape` (Procrustes) statistic**, which is promiscuous across *all* latent spaces — `orientation`→`shape`=1.00 and `shape`→`delta`/`angle` are large under both `concat` and `pls`.
+
+2. **PLS is the best production measurement space for size/orientation**, and it specifically removes the `magnitude`→`shape` artifact that the `concat` baseline manufactured. SNF is recorded as unusable for `delta`/`angle` (no power, saturated shape).
+
+3. **Decision: Rung 4 = specificity of the Procrustes `shape` statistic.** Characterize why `orientation` rejects `shape` (1.00 everywhere) and why `shape` rejects `delta`/`angle`, isolating whether it is the GPA alignment, the shape-distance null, or the `n_stages≥3` trajectory construction. This is the largest residual cross-talk and — unlike the projector — it is *latent-space-invariant*, so it lives in the estimator/test, not the integration step. (The `concat`→`pls` shape fix for `magnitude` suggests dimensionality matters; Rung 4 should sweep the latent dimension as a secondary axis.)
+
+**Exact reproduction:** seeds 0–5; `n_samples=160`, `n_stages=4`, `effect_size=1.0`, `p_dmp=0.2`, `permutations=49`; PLS CV `n_repeats=2, cv2=4, cv1=3, max_components=8`; serial; driver `scripts/latent_space_crosstalk_probe.py`. Coarse resolution (6 reps) — qualitative reads; a higher-replicate confirmation is advisable before the Rung-4 writeup leans on the exact rates.

--- a/openspec/changes/rung3-latent-space-crosstalk/proposal.md
+++ b/openspec/changes/rung3-latent-space-crosstalk/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Rungs 0–2 isolated the trajectory cross-talk question one factor at a time on a **generator-free test bed**: Rung 0 proved the linear floor is clean under PCA; Rung 1 showed the methylation `rev.logit` is invertible and not a standing cross-talk source; Rung 2 swept the projector and found per-feature `standardize`/`concat` clean, `snf` leaky (magnitude→~70° angle), and stage-conditioned PLS-DA non-leaking but **lossy** (compresses orientation at low component counts).
+
+But the cross-talk the whole ladder is chasing was first observed in the **dominant-specificity study** (`specificity.py`) — which runs the *full production generator + RRPP rejection rates*, not the injected-geometry test bed — and that study has only ever been run through the **`concat` baseline**. PR #23 established that `concat` is a *baseline/diagnostic*, not a production latent space: the production latent spaces are **SNF** (graph-spectral) and the newly-implemented **PLS** (stage-conditioned, double-CV-sized). So the specificity-study cross-talk has never been measured through a real production latent space.
+
+This rung asks the direct end-to-end question: **does the per-statistic cross-talk reproduce through the production PLS latent space, or was it a `concat`-baseline artifact?** Rung 2 predicts a specific signature for PLS — a clean null (no false orientation) but *attenuated orientation power* (the latent space compresses the group-specific direction) — which this rung tests on the real generator with RRPP.
+
+This **supersedes** Rung 2's gate decision ("Rung 3 = heterogeneous multi-omic concatenation"). That plan targeted a property of the `concat` baseline; with `concat` reclassified as a baseline and the real PLS latent space now available, the higher-value question is cross-talk through the production latent spaces, not through the baseline's concatenation geometry.
+
+## What Changes
+
+- **Make the specificity instrumentation latent-space-selectable.** Thread `integration_method` / `integration_params` through `evaluate_mode_specificity` and `characterize_two_stage` (default `concat` for backward compatibility), so the per-statistic RRPP rejection-rate study can run through `concat`, `snf`, or `pls`. The group-in-stage projection (`_group_in_stage_fraction`) uses the same selected latent space.
+- **Add a Rung-3 driver** that runs each trajectory mode (`magnitude`/`orientation`/`shape`/`none`) through the three latent spaces on matched seeds and effect size, reporting the per-statistic (`delta`/`angle`/`shape`) rejection-rate table and the group-in-stage fraction per latent space — with modest PLS cross-validation knobs (double-CV per replicate is the cost driver).
+- **Findings writeup** (matching the Rung-0/1/2 pattern): the per-latent-space rejection-rate tables; whether magnitude→orientation (and shape) cross-talk reproduces through PLS; confirmation or refutation of Rung 2's "PLS clean-null but lossy" prediction on the real generator; and the gate decision for the next rung.
+
+## Capabilities
+
+### New Capabilities
+- `latent-space-crosstalk-study`: Run the dominant-specificity per-statistic RRPP rejection-rate study through a *selectable production latent space* (`concat` baseline, `snf`, or `pls`) on the full semi-synthetic generator, and compare per-mode cross-talk and statistic-specificity across latent spaces.
+
+### Modified Capabilities
+<!-- None: the specificity instrumentation gains an integration selector, but its rejection-rate contract is unchanged; this is additive. -->
+
+## Impact
+
+- **Modified code:** `src/motco/simulations/specificity.py` — `integration_method`/`integration_params` parameters on `evaluate_mode_specificity` and `characterize_two_stage`, forwarded to both the evaluation and the group-in-stage projection.
+- **New code:** a Rung-3 driver under `scripts/` (e.g. `latent_space_crosstalk_probe.py`); unit tests under `tests/` for the threading (each latent space runs and is recorded).
+- **New docs:** `findings.md` in the change folder.
+- **Reused, unchanged:** the generator, `evaluation.py` integration methods (incl. the new `pls`), `stats/trajectory`, `stats/permutation`.
+- **Dependencies:** none new.
+- **Depends on:** PR #23 (`feat/pls-latent-integration`) — this branch is stacked on it; merge #23 first.
+- **Cost note:** PLS integration runs double-CV once per replicate; the driver exposes CV knobs and uses modest defaults so the study runs locally in minutes, not a cluster job.
+- **Out of scope:** changing the generator, estimators, or PLS integration behavior; CLI/grid wiring of PLS (separate follow-up); a full Type I / power grid (this is the diagnostic specificity comparison at modest replicate counts).

--- a/openspec/changes/rung3-latent-space-crosstalk/specs/latent-space-crosstalk-study/spec.md
+++ b/openspec/changes/rung3-latent-space-crosstalk/specs/latent-space-crosstalk-study/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Dominant-specificity study runs through a selectable latent space
+
+The dominant-specificity instrumentation SHALL accept a latent-space selection (`integration_method` with optional `integration_params`) and run the full semi-synthetic generator → integration → `estimate_difference` → RRPP rejection-rate study in that latent space. The selection MUST apply to both the per-statistic RRPP rejection-rate evaluation and the group-in-stage projection, and MUST default to the `concat` baseline so existing callers are unchanged.
+
+#### Scenario: Study runs in the PLS latent space
+- **WHEN** a caller selects `pls` integration for `evaluate_mode_specificity`
+- **THEN** each replicate is measured in the PLS molecular latent space and the per-statistic (`delta`/`angle`/`shape`) rejection rates and group-in-stage fraction are reported for that space
+
+#### Scenario: Latent space applies to the group-in-stage projection
+- **WHEN** a latent space is selected
+- **THEN** the group-in-stage fraction is computed in the same selected latent space as the rejection-rate evaluation
+
+#### Scenario: Default is the concat baseline
+- **WHEN** no integration method is specified
+- **THEN** the study runs through the `concat` baseline, reproducing the prior behavior
+
+### Requirement: Cross-latent-space comparison driver
+
+The system SHALL provide a driver that runs each trajectory mode (`magnitude`, `orientation`, `shape`, `none`) through the `concat`, `snf`, and `pls` latent spaces on matched seeds and effect size, and reports the per-statistic rejection-rate table and group-in-stage fraction per latent space.
+
+#### Scenario: Matched comparison across latent spaces
+- **WHEN** the driver is run
+- **THEN** the only varied factor across the reported tables is the latent space (seeds, effect size, stages, and permutation count are held identical), so differences in rejection rates are attributable to the latent space

--- a/openspec/changes/rung3-latent-space-crosstalk/tasks.md
+++ b/openspec/changes/rung3-latent-space-crosstalk/tasks.md
@@ -1,25 +1,25 @@
 # Tasks — Rung 3: cross-talk through the production latent spaces
 
 ## 1. Instrumentation
-- [ ] 1.1 Add `integration_method` + `integration_params` parameters (default `concat`, `None`) to `evaluate_mode_specificity`; forward them to the RRPP `evaluate_semisynthetic_trajectory` call.
-- [ ] 1.2 Forward the same selection to the group-in-stage projection (`_group_in_stage_fraction` via its `SimulationEvaluationParams`), so the projection is measured in the selected latent space.
-- [ ] 1.3 Pass-through `integration_method`/`integration_params` in `characterize_two_stage`.
-- [ ] 1.4 Record the effective integration method (and PLS selected-LV / CV params where applicable) in the returned/printed summary.
+- [x] 1.1 Add `integration_method` + `integration_params` parameters (default `concat`, `None`) to `evaluate_mode_specificity`; forward them to the RRPP `evaluate_semisynthetic_trajectory` call.
+- [x] 1.2 Forward the same selection to the group-in-stage projection (`_group_in_stage_fraction` via its `SimulationEvaluationParams`), so the projection is measured in the selected latent space.
+- [x] 1.3 Pass-through `integration_method`/`integration_params` in `characterize_two_stage`.
+- [x] 1.4 Record the effective integration method (and PLS selected-LV / CV params where applicable) in the returned/printed summary.
 
 ## 2. Driver
-- [ ] 2.1 Add `scripts/latent_space_crosstalk_probe.py`: run each mode through `concat`/`snf`/`pls` on matched seeds + effect size, with modest PLS CV knobs.
-- [ ] 2.2 Print the per-statistic rejection-rate table and group-in-stage fraction per latent space, in a findings-ready layout.
+- [x] 2.1 Add `scripts/latent_space_crosstalk_probe.py`: run each mode through `concat`/`snf`/`pls` on matched seeds + effect size, with modest PLS CV knobs.
+- [x] 2.2 Print the per-statistic rejection-rate table and group-in-stage fraction per latent space, in a findings-ready layout.
 
 ## 3. Tests
-- [ ] 3.1 `evaluate_mode_specificity` runs through `pls` and records the integration method (fast: tiny replicate/permutation/CV counts).
-- [ ] 3.2 Backward compatibility: the default path is still `concat` (existing behavior unchanged).
-- [ ] 3.3 `characterize_two_stage` forwards the latent-space selection.
+- [x] 3.1 `evaluate_mode_specificity` runs through `pls` and records the integration method (fast: tiny replicate/permutation/CV counts).
+- [x] 3.2 Backward compatibility: the default path is still `concat` (existing behavior unchanged).
+- [x] 3.3 `characterize_two_stage` forwards the latent-space selection.
 
 ## 4. Findings
-- [ ] 4.1 Run the driver; capture per-latent-space rejection-rate tables.
-- [ ] 4.2 Write `findings.md`: does cross-talk reproduce through PLS? confirm/refute Rung 2's "clean-null but lossy" prediction on the real generator; gate decision for the next rung.
+- [x] 4.1 Run the driver; capture per-latent-space rejection-rate tables.
+- [x] 4.2 Write `findings.md`: does cross-talk reproduce through PLS? confirm/refute Rung 2's "clean-null but lossy" prediction on the real generator; gate decision for the next rung.
 
 ## 5. Gate
-- [ ] 5.1 `ruff check src/ tests/` passes.
-- [ ] 5.2 `mypy src/motco/` passes.
-- [ ] 5.3 `MOTCO_TEST_PERMS=99 pytest tests/ -m "not slow"` passes.
+- [x] 5.1 `ruff check src/ tests/` passes.
+- [x] 5.2 `mypy src/motco/` passes.
+- [x] 5.3 `MOTCO_TEST_PERMS=99 pytest tests/ -m "not slow"` passes.

--- a/openspec/changes/rung3-latent-space-crosstalk/tasks.md
+++ b/openspec/changes/rung3-latent-space-crosstalk/tasks.md
@@ -1,0 +1,25 @@
+# Tasks — Rung 3: cross-talk through the production latent spaces
+
+## 1. Instrumentation
+- [ ] 1.1 Add `integration_method` + `integration_params` parameters (default `concat`, `None`) to `evaluate_mode_specificity`; forward them to the RRPP `evaluate_semisynthetic_trajectory` call.
+- [ ] 1.2 Forward the same selection to the group-in-stage projection (`_group_in_stage_fraction` via its `SimulationEvaluationParams`), so the projection is measured in the selected latent space.
+- [ ] 1.3 Pass-through `integration_method`/`integration_params` in `characterize_two_stage`.
+- [ ] 1.4 Record the effective integration method (and PLS selected-LV / CV params where applicable) in the returned/printed summary.
+
+## 2. Driver
+- [ ] 2.1 Add `scripts/latent_space_crosstalk_probe.py`: run each mode through `concat`/`snf`/`pls` on matched seeds + effect size, with modest PLS CV knobs.
+- [ ] 2.2 Print the per-statistic rejection-rate table and group-in-stage fraction per latent space, in a findings-ready layout.
+
+## 3. Tests
+- [ ] 3.1 `evaluate_mode_specificity` runs through `pls` and records the integration method (fast: tiny replicate/permutation/CV counts).
+- [ ] 3.2 Backward compatibility: the default path is still `concat` (existing behavior unchanged).
+- [ ] 3.3 `characterize_two_stage` forwards the latent-space selection.
+
+## 4. Findings
+- [ ] 4.1 Run the driver; capture per-latent-space rejection-rate tables.
+- [ ] 4.2 Write `findings.md`: does cross-talk reproduce through PLS? confirm/refute Rung 2's "clean-null but lossy" prediction on the real generator; gate decision for the next rung.
+
+## 5. Gate
+- [ ] 5.1 `ruff check src/ tests/` passes.
+- [ ] 5.2 `mypy src/motco/` passes.
+- [ ] 5.3 `MOTCO_TEST_PERMS=99 pytest tests/ -m "not slow"` passes.

--- a/scripts/latent_space_crosstalk_probe.py
+++ b/scripts/latent_space_crosstalk_probe.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Rung 3 — trajectory cross-talk through the production latent spaces.
+
+Runs the dominant-specificity per-statistic RRPP rejection-rate study through
+each latent space — the ``concat`` baseline, ``snf``, and the production ``pls``
+space — on identical seeds, effect size, stages, and permutation count, so the
+only varied factor is the latent space. For each mode (``none``, ``magnitude``,
+``orientation``, ``shape``) it reports the per-statistic (``delta``/``angle``/
+``shape``) rejection rate and the group-in-stage fraction per latent space.
+
+A *specific* construction rejects predominantly on its target statistic
+(``magnitude``→``delta``, ``orientation``→``angle``, ``shape``→``shape``);
+off-target rejections are cross-talk. Read ``pls``/``snf`` relative to the
+``concat`` baseline on the *same generator* — not against the Rung-2 test-bed
+numbers (the production path also carries generator coupling + ``rev.logit``).
+
+PLS integration runs ``plsda_doubleCV`` once per replicate; keep ``--reps``
+modest and the CV knobs small. Serial (``n_jobs=1``) for the small perm counts.
+
+Example:
+
+    python scripts/latent_space_crosstalk_probe.py \
+        --reps 10 --perms 99 --n-samples 180 --n-stages 4 \
+        --out /tmp/rung3_latent_space_crosstalk.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from motco.simulations.reference import load_reference
+from motco.simulations.specificity import TARGET_STATISTIC, evaluate_mode_specificity
+
+#: Modes carried through every latent space (geometry movers + null control).
+_MODES: tuple[str, ...] = ("none", "magnitude", "orientation", "shape")
+
+#: Latent spaces compared: (label, integration_method).
+_LATENT_SPACES: tuple[tuple[str, str], ...] = (
+    ("concat (baseline)", "concat"),
+    ("snf", "snf"),
+    ("pls", "pls"),
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Rung 3: cross-talk through the production latent spaces.")
+    p.add_argument("--reps", type=int, default=10, help="Replicates per cell (default: 10)")
+    p.add_argument("--perms", type=int, default=99, help="RRPP permutations (default: 99)")
+    p.add_argument("--n-samples", type=int, default=180, help="Samples per dataset (default: 180)")
+    p.add_argument("--n-stages", type=int, default=4, help="Trajectory stages (default: 4)")
+    p.add_argument("--effect-size", type=float, default=1.0, help="Group effect size (default: 1.0)")
+    p.add_argument("--p-dmp", type=float, default=0.2, help="Per-stage methylation DMP prob (default: 0.2)")
+    p.add_argument("--base-seed", type=int, default=0, help="Base seed (default: 0)")
+    p.add_argument("--n-jobs", type=int, default=1, help="RRPP parallel workers; -1 = all CPUs (default: 1)")
+    # PLS double-CV knobs (kept small; double-CV runs once per replicate).
+    p.add_argument("--pls-repeats", type=int, default=3, help="PLS CV n_repeats (default: 3)")
+    p.add_argument("--pls-cv2", type=int, default=4, help="PLS outer CV splits (default: 4)")
+    p.add_argument("--pls-cv1", type=int, default=3, help="PLS inner CV splits (default: 3)")
+    p.add_argument("--pls-max-components", type=int, default=15, help="PLS max LV candidates (default: 15)")
+    p.add_argument("--out", type=str, default=None, help="Write the markdown report here (default: stdout)")
+    return p
+
+
+def _integration_params(label: str, method: str, args: argparse.Namespace) -> dict[str, object]:
+    if method == "pls":
+        return {
+            "n_repeats": args.pls_repeats,
+            "cv2_splits": args.pls_cv2,
+            "cv1_splits": args.pls_cv1,
+            "max_components": args.pls_max_components,
+        }
+    return {}
+
+
+def _table(reports: dict[str, dict[str, object]]) -> list[str]:
+    lines = [
+        "## Per-statistic rejection rates by latent space",
+        "",
+        "Target statistic per mode: `magnitude`→`delta`, `orientation`→`angle`, "
+        "`shape`→`shape`. Off-target rejection = cross-talk. `*` marks the target cell.",
+        "",
+        "| latent space | mode | delta | angle | shape | group-in-stage |",
+        "|--------------|------|-------|-------|-------|----------------|",
+    ]
+    for label, _ in _LATENT_SPACES:
+        for mode in _MODES:
+            r = reports[label][mode]
+            target = TARGET_STATISTIC.get(mode)
+            cells = {}
+            for stat in ("delta", "angle", "shape"):
+                value = r.rejection_rates[stat]  # type: ignore[attr-defined]
+                text = "—" if value != value else f"{value:.2f}"  # nan check
+                cells[stat] = f"**{text}**" if stat == target else text
+            lines.append(
+                f"| {label} | `{mode}` | {cells['delta']} | {cells['angle']} | "
+                f"{cells['shape']} | {r.group_in_stage_fraction:.2f} |"  # type: ignore[attr-defined]
+            )
+    lines.append("")
+    return lines
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    ref = load_reference()
+    common = dict(
+        n_replicates=args.reps,
+        n_samples=args.n_samples,
+        n_stages=args.n_stages,
+        effect_size=args.effect_size,
+        p_dmp=args.p_dmp,
+        permutations=args.perms,
+        n_jobs=args.n_jobs,
+        base_seed=args.base_seed,
+        reference=ref,
+    )
+
+    reports: dict[str, dict[str, object]] = {}
+    for label, method in _LATENT_SPACES:
+        reports[label] = {}
+        int_params = _integration_params(label, method, args)
+        for mode in _MODES:
+            print(f"[{label}] {mode}...", file=sys.stderr)
+            reports[label][mode] = evaluate_mode_specificity(
+                mode,  # type: ignore[arg-type]
+                integration_method=method,
+                integration_params=int_params,
+                **common,
+            )
+
+    out = [
+        "# Rung 3 — cross-talk through the production latent spaces",
+        "",
+        f"Run: {args.reps} reps, {args.perms} perms, `n_samples={args.n_samples}`, "
+        f"`n_stages={args.n_stages}`, `effect_size={args.effect_size}`, `p_dmp={args.p_dmp}`, "
+        f"serial (`n_jobs=1`). PLS CV: repeats={args.pls_repeats}, cv2={args.pls_cv2}, "
+        f"cv1={args.pls_cv1}, max_components={args.pls_max_components}.",
+        "",
+    ]
+    out += _table(reports)
+
+    report = "\n".join(out)
+    if args.out:
+        Path(args.out).write_text(report)
+        print(f"Wrote {args.out}", file=sys.stderr)
+    else:
+        print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/motco/simulations/specificity.py
+++ b/src/motco/simulations/specificity.py
@@ -54,6 +54,7 @@ class ModeSpecificity:
     rejection_rates: dict[str, float]
     group_in_stage_fraction: float
     n_replicates: int
+    integration_method: str = "concat"
 
 
 @dataclass(frozen=True)
@@ -121,11 +122,26 @@ def evaluate_mode_specificity(
     n_jobs: int | None = -1,
     base_seed: int = 0,
     reference: IntersimReference | None = None,
+    integration_method: str = "concat",
+    integration_params: dict[str, object] | None = None,
 ) -> ModeSpecificity:
-    """Run replicates for one mode and report per-statistic rejection rates."""
+    """Run replicates for one mode and report per-statistic rejection rates.
+
+    ``integration_method`` selects the latent space the trajectory is measured
+    in — the ``concat`` baseline (default), ``snf``, or the ``pls`` production
+    latent space — and ``integration_params`` is forwarded to it (e.g. the PLS
+    cross-validation knobs). The same selection drives both the RRPP
+    rejection-rate evaluation and the group-in-stage projection.
+    """
 
     ref = reference if reference is not None else load_reference()
-    eval_params = SimulationEvaluationParams(permutations=permutations, n_jobs=n_jobs)
+    int_params = dict(integration_params or {})
+    eval_params = SimulationEvaluationParams(
+        permutations=permutations,
+        n_jobs=n_jobs,
+        integration_method=integration_method,  # type: ignore[arg-type]
+        integration_params=int_params,
+    )
     rejections = {stat: 0 for stat in STATISTICS}
     available = {stat: 0 for stat in STATISTICS}
     gis_values: list[float] = []
@@ -143,7 +159,14 @@ def evaluate_mode_specificity(
         )
         dataset = generate_semisynthetic_trajectory(params, reference=ref)
         result = evaluate_semisynthetic_trajectory(
-            dataset, SimulationEvaluationParams(permutations=permutations, n_jobs=n_jobs, seed=base_seed + rep)
+            dataset,
+            SimulationEvaluationParams(
+                permutations=permutations,
+                n_jobs=n_jobs,
+                seed=base_seed + rep,
+                integration_method=integration_method,  # type: ignore[arg-type]
+                integration_params=int_params,
+            ),
         )
         for stat in STATISTICS:
             p = result.p_values.get(stat)
@@ -162,6 +185,7 @@ def evaluate_mode_specificity(
         rejection_rates=rates,
         group_in_stage_fraction=float(np.mean(gis_values)),
         n_replicates=n_replicates,
+        integration_method=integration_method,
     )
 
 
@@ -177,6 +201,8 @@ def characterize_two_stage(
     n_jobs: int | None = -1,
     base_seed: int = 0,
     reference: IntersimReference | None = None,
+    integration_method: str = "concat",
+    integration_params: dict[str, object] | None = None,
 ) -> dict[str, ModeSpecificity]:
     """Run the shape-free (``n_stages=2``) isolation pass for each mode.
 
@@ -185,6 +211,9 @@ def characterize_two_stage(
     isolates ``magnitude``→``delta`` and ``orientation``→``angle`` with shape out
     of the picture — the cleanest test of whether the constructions are specific
     or whether the 3/4-stage cross-talk was shape contaminating them.
+
+    ``integration_method``/``integration_params`` select the latent space, as in
+    :func:`evaluate_mode_specificity`.
     """
 
     ref = reference if reference is not None else load_reference()
@@ -201,6 +230,8 @@ def characterize_two_stage(
             n_jobs=n_jobs,
             base_seed=base_seed,
             reference=ref,
+            integration_method=integration_method,
+            integration_params=integration_params,
         )
         for mode in modes
     }

--- a/tests/test_specificity_latent_space.py
+++ b/tests/test_specificity_latent_space.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from motco.simulations.specificity import (
+    STATISTICS,
+    characterize_two_stage,
+    evaluate_mode_specificity,
+)
+
+# Tiny CV knobs keep the PLS double-CV cheap for the fast suite.
+_PLS_CV = {"cv2_splits": 2, "cv1_splits": 2, "n_repeats": 1, "max_components": 4}
+_COMMON = dict(n_replicates=1, n_samples=80, n_stages=2, permutations=5, n_jobs=1, base_seed=0)
+
+
+def test_mode_specificity_runs_through_pls_latent_space() -> None:
+    result = evaluate_mode_specificity(
+        "magnitude",
+        integration_method="pls",
+        integration_params=_PLS_CV,
+        **_COMMON,
+    )
+
+    assert result.integration_method == "pls"
+    # Rejection rates are reported for every statistic (shape is nan at 2 stages).
+    assert set(result.rejection_rates) == set(STATISTICS)
+    assert 0.0 <= result.group_in_stage_fraction <= 1.0
+
+
+def test_mode_specificity_defaults_to_concat_baseline() -> None:
+    result = evaluate_mode_specificity("magnitude", **_COMMON)
+
+    assert result.integration_method == "concat"
+
+
+def test_characterize_two_stage_forwards_latent_space() -> None:
+    results = characterize_two_stage(
+        modes=("magnitude",),
+        integration_method="pls",
+        integration_params=_PLS_CV,
+        n_replicates=1,
+        n_samples=80,
+        permutations=5,
+        n_jobs=1,
+        base_seed=0,
+    )
+
+    assert results["magnitude"].integration_method == "pls"


### PR DESCRIPTION
## Why

The cross-talk the rung ladder has been chasing was first observed in the **dominant-specificity study** (full generator + RRPP rejection rates) — and that study has only ever run through the **`concat` baseline**. PR #23 established `concat` is a baseline, not a production latent space (the production spaces are **SNF** and the new **PLS**). This rung makes the specificity instrumentation latent-space-selectable and asks: does the cross-talk reproduce through the real PLS latent space, or was it a `concat` artifact?

Supersedes Rung 2's now-moot "Rung 3 = heterogeneous concat" gate.

## What changed

- Thread `integration_method`/`integration_params` through `evaluate_mode_specificity` + `characterize_two_stage` (default `concat`, backward-compatible), applied to **both** the RRPP evaluation and the group-in-stage projection.
- New driver `scripts/latent_space_crosstalk_probe.py` (each mode through `concat`/`snf`/`pls`, with `--n-jobs`).
- Tests for the PLS path, the `concat` default, and two-stage forwarding.
- `findings.md` with the per-latent-space rejection-rate tables and the Rung-4 gate.

## Headline findings

1. **The feared magnitude→orientation leak is essentially absent** on the real generator (≤0.17 everywhere). The dominant cross-talk is the **Procrustes `shape` statistic**, and it is **latent-space-invariant**: `orientation`→`shape`=1.00 under `concat`, `snf`, *and* `pls`; `shape`→`delta`/`angle` is large under `concat` and `pls`. So the culprit is the estimator/test, not the projector.
2. **PLS removes the magnitude→shape contamination** the `concat` baseline manufactured (`magnitude`→`shape` 1.00 → 0.00), with a clean null and strong `magnitude`→`delta`. The part that *was* a baseline artifact is now identified.
3. **SNF has no `delta`/`angle` power** (0.00 for every mode) and a saturated/anti-conservative `shape` — unusable as the measurement space for size/orientation.
4. **Structural:** PLS confines the group signal to the stage subspace (group-in-stage = 1.00 vs `concat` ~0.1) — focuses on disease-relevant variation but discards group variation orthogonal to the stage axis.

## Gate → Rung 4

**Rung 4 = specificity of the Procrustes `shape` statistic** — the largest residual cross-talk, and (unlike the projector) latent-space-invariant, so it lives in the estimator. Sweep latent dimension as a secondary axis (the `concat`→`pls` shape fix for `magnitude` suggests dimensionality matters).

## Caveats

Coarse resolution (6 reps → 1/6 granularity); qualitative direction reads, not power estimates. A higher-replicate confirmation is advisable before Rung 4 leans on exact rates. Read `pls`/`snf` relative to `concat` on the same generator, not against the Rung-2 test-bed numbers.

Gate: ruff + mypy clean; 304 passed / 2 skipped (R) / 7 slow-deselected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)